### PR TITLE
85 cross canister calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target
 build
 kybra.egg-info
 node_modules
+__pycache__

--- a/kybra/__main__.py
+++ b/kybra/__main__.py
@@ -10,6 +10,8 @@ from pathlib import Path
 # This is the name of the canister passed into python -m kybra from the dfx.json build command
 canister_name = sys.argv[1]
 
+print(f'\nBuilding canister {canister_name}\n')
+
 # This is the path to the developer's entry point Python file passed into python -m kybra from the dfx.json build command
 py_entry_file_path = sys.argv[2]
 
@@ -94,12 +96,15 @@ py_file_names_file.write(','.join(py_file_names))
 py_file_names_file.close()
 
 # Generate the Rust code
+print('[1/3] 🔨 Compiling Python...')
 os.system(f'CARGO_TARGET_DIR={target_path} cargo run --manifest-path {canister_path}/kybra_generate/Cargo.toml {py_file_names_file_path} {py_entry_module_name} | rustfmt --edition 2018 > {lib_path}')
 
 # Compile the generated Rust code
+print('[2/3] 🚧 Building Wasm binary...')
 os.system(f'CARGO_TARGET_DIR={target_path} cargo build --manifest-path {canister_path}/Cargo.toml --target wasm32-unknown-unknown --package kybra_generated_canister --release')
 
 # Generate the Candid file
+print('[3/3] 📝 Generating Candid file...')
 os.system(f'CARGO_TARGET_DIR={target_path} cargo test --manifest-path {canister_path}/Cargo.toml')
 
 # Copy the generated Candid file to the developer's source directory

--- a/kybra/compiler/kybra_generate/Cargo.toml
+++ b/kybra/compiler/kybra_generate/Cargo.toml
@@ -10,6 +10,6 @@ proc-macro2 = "1.0.43"
 rustpython-parser = { git = "https://github.com/demergent-labs/RustPython", branch = "kybra_initial", default-features = false, features = [] }
 annotate-snippets = "0.9.1"
 # rustpython = { path = "../../../../RustPython", default-features = false, features = [] }
-cdk_framework = { git = "https://github.com/demergent-labs/cdk_framework", rev = "6527827e8f4113f3bf9c273d3ebf053d88341ca9" }
+cdk_framework = { git = "https://github.com/demergent-labs/cdk_framework", rev = "61d38c62d62ce2f112d722fb2926755930143b99" }
 # cdk_framework = { path = "../../../../cdk_framework" } # For local rust-analyzer
 # cdk_framework = { path = "../../../../../../../cdk_framework" } # For local deployment in kybra/examples

--- a/kybra/compiler/kybra_generate/src/lib.rs
+++ b/kybra/compiler/kybra_generate/src/lib.rs
@@ -41,6 +41,7 @@ pub fn kybra_generate(
     eprintln!("-------------------------------------------");
 
     quote! {
+        use ic_cdk::api::call::CallResult;
         use rustpython_vm::{AsObject, builtins::{PyGenerator, PyListRef, PyTupleRef, PyIntRef}, class::PyClassImpl, convert::ToPyObject, function::IntoFuncArgs, PyObjectRef, VirtualMachine, protocol::{PyIter, PyIterReturn}};
         use rustpython_derive::{pyclass, PyPayload};
         use kybra_vm_value_derive::{CdkActTryIntoVmValue, CdkActTryFromVmValue};

--- a/kybra/compiler/kybra_generate/src/py_ast/kybra_ast/mod.rs
+++ b/kybra/compiler/kybra_generate/src/py_ast/kybra_ast/mod.rs
@@ -1,16 +1,16 @@
-mod to_act;
-
-use proc_macro2::TokenStream;
-
 use cdk_framework::{
     nodes::{
-        ActHeartbeatMethod, ActInitMethod, ActInspectMessageMethod, ActPostUpgradeMethod,
-        ActPreUpgradeMethod,
+        ActExternalCanister, ActHeartbeatMethod, ActInitMethod, ActInspectMessageMethod,
+        ActPostUpgradeMethod, ActPreUpgradeMethod,
     },
     ActCanisterMethod, ActDataType,
 };
+use proc_macro2::TokenStream;
+
+mod to_act;
 
 pub struct KybraAst {
+    pub external_canisters: Vec<ActExternalCanister>,
     pub canister_methods: Vec<ActCanisterMethod>,
     pub canister_types: Vec<ActDataType>,
     pub init_method: ActInitMethod,

--- a/kybra/compiler/kybra_generate/src/py_ast/kybra_ast/to_act.rs
+++ b/kybra/compiler/kybra_generate/src/py_ast/kybra_ast/to_act.rs
@@ -103,6 +103,8 @@ impl ToAct for KybraAst {
         let post_upgrade_method = self.post_upgrade.clone();
         let pre_upgrade_method = self.pre_upgrade.clone();
 
+        let external_canisters = self.external_canisters.clone();
+
         let try_into_vm_value_impls = try_into_vm_value::generate_try_into_vm_value_impls();
         let try_from_vm_value_impls = try_from_vm_value::generate_try_from_vm_value_impls();
 
@@ -118,6 +120,7 @@ impl ToAct for KybraAst {
             pre_upgrade_method,
             rust_code,
             arrays,
+            external_canisters,
             funcs,
             options,
             primitives,
@@ -127,7 +130,6 @@ impl ToAct for KybraAst {
             tuples,
             type_refs,
             variants,
-            external_canisters: vec![],
         }
     }
 }

--- a/kybra/compiler/kybra_generate/src/py_ast/kybra_ast/to_act.rs
+++ b/kybra/compiler/kybra_generate/src/py_ast/kybra_ast/to_act.rs
@@ -120,7 +120,6 @@ impl ToAct for KybraAst {
             pre_upgrade_method,
             rust_code,
             arrays,
-            external_canisters,
             funcs,
             options,
             primitives,
@@ -130,6 +129,7 @@ impl ToAct for KybraAst {
             tuples,
             type_refs,
             variants,
+            external_canisters,
         }
     }
 }

--- a/kybra/compiler/kybra_generate/src/py_ast/kybra_types/kybra_arguments/mod.rs
+++ b/kybra/compiler/kybra_generate/src/py_ast/kybra_types/kybra_arguments/mod.rs
@@ -11,27 +11,28 @@ pub struct KybraArguments<'a> {
 }
 
 impl KybraArguments<'_> {
-    pub fn to_act_fn_params(&self) -> Result<Vec<ActFnParam>, &str> {
+    pub fn to_act_fn_params(&self) -> Result<Vec<ActFnParam>, String> {
         if self.arguments.kwarg.is_some() {
-            return Err("the dictionary unpacking operator (**) is not supported");
+            return Err("the dictionary unpacking operator (**) is not supported".to_string());
         }
 
         if self.arguments.vararg.is_some() {
-            return Err("the iterator unpacking operator (*) is not supported");
+            return Err("the iterator unpacking operator (*) is not supported".to_string());
         }
 
         if self.arguments.args.len() == 0 {
-            return Err("method must contain at least \"self\" as a parameter");
+            return Err(
+                "method must be an instance method. Add \"self\" as the first parameter"
+                    .to_string(),
+            );
         }
 
         if self.arguments.args[0].node.arg != "self".to_string() {
-            return Err("first argument must be \"self\"");
+            return Err("first parameter must be \"self\"".to_string());
         }
 
         // Ignore the first param, which is always "self"
-        let subset = &self.arguments.args[1..];
-
-        subset
+        self.arguments.args[1..]
             .iter()
             .map(|arg| {
                 let name = &arg.node.arg;
@@ -49,7 +50,7 @@ impl KybraArguments<'_> {
                             data_type,
                         })
                     }
-                    None => Err("missing"),
+                    None => Err(format!("parameter \"{}\" is missing a type annotation. All method parameters must specify their type.", &name)),
                 }
             })
             .collect()

--- a/kybra/compiler/kybra_generate/src/py_ast/kybra_types/kybra_arguments/mod.rs
+++ b/kybra/compiler/kybra_generate/src/py_ast/kybra_types/kybra_arguments/mod.rs
@@ -1,0 +1,57 @@
+use cdk_framework::{nodes::ActFnParam, ToActDataType};
+use rustpython_parser::ast::Arguments;
+
+use crate::source_map::SourceMap;
+
+use super::KybraExpr;
+
+pub struct KybraArguments<'a> {
+    pub arguments: &'a Arguments,
+    pub source_map: &'a SourceMap,
+}
+
+impl KybraArguments<'_> {
+    pub fn to_act_fn_params(&self) -> Result<Vec<ActFnParam>, &str> {
+        if self.arguments.kwarg.is_some() {
+            return Err("the dictionary unpacking operator (**) is not supported");
+        }
+
+        if self.arguments.vararg.is_some() {
+            return Err("the iterator unpacking operator (*) is not supported");
+        }
+
+        if self.arguments.args.len() == 0 {
+            return Err("method must contain at least \"self\" as a parameter");
+        }
+
+        if self.arguments.args[0].node.arg != "self".to_string() {
+            return Err("first argument must be \"self\"");
+        }
+
+        // Ignore the first param, which is always "self"
+        let subset = &self.arguments.args[1..];
+
+        subset
+            .iter()
+            .map(|arg| {
+                let name = &arg.node.arg;
+
+                match &arg.node.annotation {
+                    Some(annotation) => {
+                        let data_type = KybraExpr {
+                            located_expr: annotation.as_ref(),
+                            source_map: self.source_map,
+                        }
+                        .to_act_data_type(&None);
+
+                        Ok(ActFnParam {
+                            name: name.to_string(),
+                            data_type,
+                        })
+                    }
+                    None => Err("missing"),
+                }
+            })
+            .collect()
+    }
+}

--- a/kybra/compiler/kybra_generate/src/py_ast/kybra_types/kybra_program/build_external_canisters.rs
+++ b/kybra/compiler/kybra_generate/src/py_ast/kybra_types/kybra_program/build_external_canisters.rs
@@ -1,0 +1,30 @@
+use cdk_framework::nodes::ActExternalCanister;
+use rustpython_parser::ast::Mod;
+
+use super::KybraProgram;
+use crate::py_ast::KybraStmt;
+
+impl KybraProgram<'_> {
+    pub fn build_external_canisters(&self) -> Vec<ActExternalCanister> {
+        match &self.program {
+            Mod::Module { body, .. } => body
+                .iter()
+                .filter(|stmt_kind| {
+                    KybraStmt {
+                        stmt_kind,
+                        source_map: self.source_map,
+                    }
+                    .is_external_canister()
+                })
+                .map(|stmt_kind| {
+                    KybraStmt {
+                        stmt_kind,
+                        source_map: self.source_map,
+                    }
+                    .to_act_external_canister()
+                })
+                .collect(),
+            _ => vec![],
+        }
+    }
+}

--- a/kybra/compiler/kybra_generate/src/py_ast/kybra_types/kybra_program/mod.rs
+++ b/kybra/compiler/kybra_generate/src/py_ast/kybra_types/kybra_program/mod.rs
@@ -7,6 +7,8 @@ use cdk_framework::{ActCanisterMethod, ActDataType, CanisterMethodType};
 
 use super::KybraStmt;
 
+mod build_external_canisters;
+
 pub struct KybraProgram<'a> {
     pub program: Mod,
     pub source_map: &'a SourceMap,

--- a/kybra/compiler/kybra_generate/src/py_ast/kybra_types/kybra_stmt/external_canisters/mod.rs
+++ b/kybra/compiler/kybra_generate/src/py_ast/kybra_types/kybra_stmt/external_canisters/mod.rs
@@ -1,0 +1,70 @@
+use cdk_framework::{
+    nodes::{ActExternalCanister, ActExternalCanisterMethod},
+    ToActDataType,
+};
+use rustpython_parser::ast::{ExprKind, StmtKind};
+
+use super::KybraStmt;
+use crate::py_ast::kybra_types::{KybraArguments, KybraExpr};
+
+impl KybraStmt<'_> {
+    pub fn to_act_external_canister(&self) -> ActExternalCanister {
+        match &self.stmt_kind.node {
+            StmtKind::ClassDef { name, body, .. } => {
+                let canister_name = name.clone();
+                let methods: Vec<ActExternalCanisterMethod> = body
+                    .iter()
+                    .map(|located_statement| -> ActExternalCanisterMethod {
+                        match &located_statement.node {
+                            StmtKind::FunctionDef { name, args, body: _, decorator_list: _, returns, type_comment: _ } => {
+                                let params = KybraArguments {
+                                    arguments: args.as_ref(),
+                                    source_map: self.source_map
+                                }.to_act_fn_params()
+                                 .unwrap_or_else(|e| panic!("{}.{} violates Kybra requirements: {}", canister_name, name, e) );
+
+                                let expr_kind = returns.as_ref().expect(&format!("{}.{} is missing a return type", canister_name, &name));
+
+                                let return_type = KybraExpr {
+                                    located_expr: expr_kind,
+                                    source_map: self.source_map,
+                                }.to_act_data_type(&None);
+
+                                ActExternalCanisterMethod {
+                                    name: name.clone(),
+                                    params,
+                                    return_type,
+                                }
+                            },
+                            _ => panic!("class \"{}\" should only contain function definitions. Please remove everything else.", name)
+                        }
+                    })
+                    .collect();
+
+                if methods.len() == 0 {
+                    panic!("class \"{}\" doesn't have any methods. External canisters are required to expose at least one method.", name)
+                }
+
+                ActExternalCanister {
+                    name: canister_name,
+                    methods,
+                }
+            }
+            // We filter out any non classDefs in KybraProgram.get_external_canister_declarations
+            _ => panic!("Oops! Looks like we introduced a bug while refactoring. Please open a ticket at https://github.com/demergent-labs/azle/issues/new"),
+        }
+    }
+
+    pub fn is_external_canister(&self) -> bool {
+        match &self.stmt_kind.node {
+            StmtKind::ClassDef { bases, .. } => bases.iter().fold(false, |acc, base| {
+                let is_external_canister = match &base.node {
+                    ExprKind::Name { id, .. } => id == "Canister",
+                    _ => false,
+                };
+                acc || is_external_canister
+            }),
+            _ => false,
+        }
+    }
+}

--- a/kybra/compiler/kybra_generate/src/py_ast/kybra_types/kybra_stmt/mod.rs
+++ b/kybra/compiler/kybra_generate/src/py_ast/kybra_types/kybra_stmt/mod.rs
@@ -1,5 +1,6 @@
 mod canister_method;
 mod data_types;
+mod external_canisters;
 mod get_dependencies;
 mod system_methods;
 mod type_alias;

--- a/kybra/compiler/kybra_generate/src/py_ast/kybra_types/mod.rs
+++ b/kybra/compiler/kybra_generate/src/py_ast/kybra_types/mod.rs
@@ -1,7 +1,9 @@
+mod kybra_arguments;
 mod kybra_expr;
 mod kybra_program;
 mod kybra_stmt;
 
+pub use kybra_arguments::KybraArguments;
 pub use kybra_expr::KybraExpr;
 pub use kybra_program::KybraProgram;
 pub use kybra_stmt::KybraStmt;

--- a/kybra/compiler/kybra_generate/src/py_ast/mod.rs
+++ b/kybra/compiler/kybra_generate/src/py_ast/mod.rs
@@ -137,7 +137,6 @@ impl PyAst<'_> {
             })
     }
 
-    // TODO: Consider catching duplicate canister and method names
     fn build_external_canisters(&self) -> Vec<ActExternalCanister> {
         self.kybra_programs
             .iter()

--- a/kybra/compiler/kybra_generate/src/py_ast/mod.rs
+++ b/kybra/compiler/kybra_generate/src/py_ast/mod.rs
@@ -4,7 +4,7 @@ use quote::quote;
 
 use crate::generators::async_result_handler::generate_async_result_handler;
 use cdk_framework::{
-    nodes::{act_canister_method, data_type_nodes},
+    nodes::{act_canister_method, data_type_nodes, ActExternalCanister},
     ActCanisterMethod, ActDataType, CanisterMethodType,
 };
 
@@ -90,6 +90,7 @@ impl PyAst<'_> {
             heartbeat: self.build_heartbeat_method(),
             canister_types: all_types,
             canister_methods: self.build_canister_methods(),
+            external_canisters: self.build_external_canisters(),
             rust_code,
         }
     }
@@ -134,5 +135,14 @@ impl PyAst<'_> {
                 acc.extend(kybra_program.get_function_defs_of_type(method_type.clone()));
                 acc
             })
+    }
+
+    // TODO: Consider catching duplicate canister and method names
+    fn build_external_canisters(&self) -> Vec<ActExternalCanister> {
+        self.kybra_programs
+            .iter()
+            .map(|program| program.build_external_canisters())
+            .collect::<Vec<Vec<ActExternalCanister>>>()
+            .concat()
     }
 }

--- a/kybra/compiler/kybra_generate/src/py_ast/what_is_it/mod.rs
+++ b/kybra/compiler/kybra_generate/src/py_ast/what_is_it/mod.rs
@@ -40,7 +40,7 @@ impl WhatIsIt for Located<StmtKind> {
                     .map(|decorator| decorator.to_display_string())
                     .collect();
                 let body_strings: Vec<String> =
-                    body.iter().map(|base| base.to_display_string()).collect();
+                    body.iter().map(|stmt| stmt.to_display_string()).collect();
                 eprintln!("These are the bases {:?}", base_strings);
                 eprintln!("These are the keywords {:?}", keyword_string);
                 eprintln!("These are the decorators {:?}", decorator_string);
@@ -65,9 +65,22 @@ impl WhatIsIt for Located<StmtKind> {
                 eprintln!("The simple is: {}", simple);
                 eprintln!(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
             }
-            StmtKind::FunctionDef { .. } => {
+            StmtKind::FunctionDef {
+                name,
+                args,
+                body,
+                decorator_list,
+                returns,
+                type_comment,
+            } => {
                 eprintln!("--------------------------------------");
                 eprintln!("This is a function def");
+                eprintln!("The name is: {}", name);
+                eprintln!("The args are: {:?}", args);
+                eprintln!("The body is: {:?}", body);
+                eprintln!("The decorators are: {:?}", decorator_list);
+                eprintln!("The returns are: {:?}", returns);
+                eprintln!("The type_comment is: {:?}", type_comment);
                 eprintln!("--------------------------------------");
             }
             StmtKind::AsyncFunctionDef { .. } => {


### PR DESCRIPTION
This parses the Python AST and creates ActExternalCanisters for each external canister declaration.

> **Warning** 
> This depends on an update to the CDK framework. We need to have ActExternalCanister derive clone before this can work.