### PR TITLE
Made compatible with CDK Framework 1147dd7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 [[package]]
 name = "cdk_framework"
 version = "0.0.0"
-source = "git+https://github.com/demergent-labs/cdk_framework?rev=0ad949d010150f509e4395dcf377313be026eaf2#0ad949d010150f509e4395dcf377313be026eaf2"
+source = "git+https://github.com/demergent-labs/cdk_framework?rev=1147dd7dac981676b0b65b8e40f9a56fabb9bca2#1147dd7dac981676b0b65b8e40f9a56fabb9bca2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/kybra/compiler/kybra_generate/Cargo.toml
+++ b/kybra/compiler/kybra_generate/Cargo.toml
@@ -10,6 +10,6 @@ proc-macro2 = "1.0.43"
 rustpython-parser = { git = "https://github.com/demergent-labs/RustPython", branch = "kybra_initial", default-features = false, features = [] }
 annotate-snippets = "0.9.1"
 # rustpython = { path = "../../../../RustPython", default-features = false, features = [] }
-cdk_framework = { git = "https://github.com/demergent-labs/cdk_framework", rev = "0ad949d010150f509e4395dcf377313be026eaf2" }
+cdk_framework = { git = "https://github.com/demergent-labs/cdk_framework", rev = "1147dd7dac981676b0b65b8e40f9a56fabb9bca2" }
 # cdk_framework = { path = "../../../../cdk_framework" } # For local rust-analyzer
 # cdk_framework = { path = "../../../../../../../cdk_framework" } # For local deployment in kybra/examples

--- a/kybra/compiler/kybra_generate/src/generators/async_result_handler.rs
+++ b/kybra/compiler/kybra_generate/src/generators/async_result_handler.rs
@@ -1,5 +1,5 @@
 use cdk_framework::{nodes::act_external_canister::ActExternalCanister, ToTokenStream};
-use proc_macro2::{Ident, TokenStream};
+use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use crate::generators::tuple;
@@ -202,8 +202,9 @@ fn generate_call_match_arms(external_canisters: &Vec<ActExternalCanister>) -> Ve
                     }
                 }).collect();
 
-                let param_names: Vec<Ident> = act_external_canister_method.params.iter().map(|act_fn_param| {
-                    format_ident!("{}", act_fn_param.prefixed_name())
+                let param_names = act_external_canister_method.params.iter().map(|act_fn_param| {
+                    let name = format_ident!("{}", act_fn_param.prefixed_name());
+                    quote! {#name}
                 }).collect();
                 let params = tuple::generate_tuple(&param_names);
 
@@ -255,8 +256,9 @@ fn generate_call_with_payment_match_arms(
                     }
                 }).collect();
 
-                let param_names: Vec<Ident> = act_external_canister_method.params.iter().map(|act_fn_param| {
-                    format_ident!("{}", act_fn_param.prefixed_name())
+                let param_names: Vec<TokenStream> = act_external_canister_method.params.iter().map(|act_fn_param| {
+                    let name = format_ident!("{}", act_fn_param.prefixed_name());
+                    quote! {#name}
                 }).collect();
                 let params = tuple::generate_tuple(&param_names);
 
@@ -312,8 +314,9 @@ fn generate_call_with_payment128_match_arms(
                     }
                 }).collect();
 
-                let param_names: Vec<Ident> = act_external_canister_method.params.iter().map(|act_fn_param| {
-                    format_ident!("{}", act_fn_param.prefixed_name())
+                let param_names: Vec<TokenStream> = act_external_canister_method.params.iter().map(|act_fn_param| {
+                    let name = format_ident!("{}", act_fn_param.prefixed_name());
+                    quote! {#name}
                 }).collect();
                 let params = tuple::generate_tuple(&param_names);
 

--- a/kybra/compiler/kybra_generate/src/generators/async_result_handler.rs
+++ b/kybra/compiler/kybra_generate/src/generators/async_result_handler.rs
@@ -1,9 +1,10 @@
 use cdk_framework::{nodes::act_external_canister::ActExternalCanister, ToTokenStream};
+use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 
-pub fn generate_async_result_handler(
-    external_canisters: &Vec<ActExternalCanister>,
-) -> proc_macro2::TokenStream {
+use crate::generators::tuple;
+
+pub fn generate_async_result_handler(external_canisters: &Vec<ActExternalCanister>) -> TokenStream {
     let call_match_arms = generate_call_match_arms(external_canisters);
     let call_with_payment_match_arms = generate_call_with_payment_match_arms(external_canisters);
     let call_with_payment128_match_arms =
@@ -174,15 +175,13 @@ CanisterResult
     }
 }
 
-fn generate_call_match_arms(
-    external_canisters: &Vec<ActExternalCanister>,
-) -> Vec<proc_macro2::TokenStream> {
+fn generate_call_match_arms(external_canisters: &Vec<ActExternalCanister>) -> Vec<TokenStream> {
     external_canisters
     .iter()
     .map(|act_external_canister| {
         let canister_name = &act_external_canister.name;
 
-        let arms: Vec<proc_macro2::TokenStream> = act_external_canister
+        let arms: Vec<TokenStream> = act_external_canister
             .methods
             .iter()
             .map(|act_external_canister_method| {
@@ -193,8 +192,8 @@ fn generate_call_match_arms(
 
                 let cross_canister_function_call_name_ident = format_ident!("{}", cross_canister_function_call_name);
 
-                let param_variable_definitions: Vec<proc_macro2::TokenStream> = act_external_canister_method.params.iter().enumerate().map(|(index, act_fn_param)| {
-                    let variable_name = format_ident!("_kybra_user_defined_var_{}", act_fn_param.name);
+                let param_variable_definitions: Vec<TokenStream> = act_external_canister_method.params.iter().enumerate().map(|(index, act_fn_param)| {
+                    let variable_name = format_ident!("{}", act_fn_param.prefixed_name());
                     let variable_type = act_fn_param.data_type.to_token_stream(&vec![]);
                     let actual_index = index + 2;
 
@@ -203,9 +202,10 @@ fn generate_call_match_arms(
                     }
                 }).collect();
 
-                let param_names: Vec<proc_macro2::Ident> = act_external_canister_method.params.iter().map(|act_fn_param| {
-                    format_ident!("_kybra_user_defined_var_{}", act_fn_param.name)
+                let param_names: Vec<Ident> = act_external_canister_method.params.iter().map(|act_fn_param| {
+                    format_ident!("{}", act_fn_param.prefixed_name())
                 }).collect();
+                let params = tuple::generate_tuple(&param_names);
 
                 quote! {
                     #cross_canister_function_call_name => {
@@ -213,7 +213,7 @@ fn generate_call_match_arms(
 
                         #(#param_variable_definitions)*
 
-                        _kybra_create_call_result_instance(vm, #cross_canister_function_call_name_ident(canister_id_principal, #(#param_names),*).await)
+                        _kybra_create_call_result_instance(vm, #cross_canister_function_call_name_ident(canister_id_principal, #params).await)
                     }
                 }
             })
@@ -228,13 +228,13 @@ fn generate_call_match_arms(
 
 fn generate_call_with_payment_match_arms(
     external_canisters: &Vec<ActExternalCanister>,
-) -> Vec<proc_macro2::TokenStream> {
+) -> Vec<TokenStream> {
     external_canisters
     .iter()
     .map(|act_external_canister| {
         let canister_name = &act_external_canister.name;
 
-        let arms: Vec<proc_macro2::TokenStream> = act_external_canister
+        let arms: Vec<TokenStream> = act_external_canister
             .methods
             .iter()
             .map(|act_external_canister_method| {
@@ -245,8 +245,8 @@ fn generate_call_with_payment_match_arms(
 
                 let cross_canister_function_call_with_payment_name_ident = format_ident!("{}", cross_canister_function_call_with_payment_name);
 
-                let param_variable_definitions: Vec<proc_macro2::TokenStream> = act_external_canister_method.params.iter().enumerate().map(|(index, act_fn_param)| {
-                    let variable_name = format_ident!("_kybra_user_defined_var_{}", act_fn_param.name);
+                let param_variable_definitions: Vec<TokenStream> = act_external_canister_method.params.iter().enumerate().map(|(index, act_fn_param)| {
+                    let variable_name = format_ident!("{}", act_fn_param.prefixed_name());
                     let variable_type = act_fn_param.data_type.to_token_stream(&vec![]);
                     let actual_index = index + 2;
 
@@ -255,11 +255,11 @@ fn generate_call_with_payment_match_arms(
                     }
                 }).collect();
 
-                let param_names: Vec<proc_macro2::Ident> = act_external_canister_method.params.iter().map(|act_fn_param| {
-                    format_ident!("_kybra_user_defined_var_{}", act_fn_param.name)
+                let param_names: Vec<Ident> = act_external_canister_method.params.iter().map(|act_fn_param| {
+                    format_ident!("{}", act_fn_param.prefixed_name())
                 }).collect();
+                let params = tuple::generate_tuple(&param_names);
 
-                let payment_comma = if act_external_canister_method.params.len() == 0 { quote! {} } else { quote! { , } };
                 let payment_index = act_external_canister_method.params.len() + 2;
                 let payment_variable_definition = quote!(let payment: u64 = args[#payment_index].clone().try_from_vm_value(vm).unwrap(););
 
@@ -270,7 +270,7 @@ fn generate_call_with_payment_match_arms(
                         #(#param_variable_definitions)*
                         #payment_variable_definition
 
-                        _kybra_create_call_result_instance(vm, #cross_canister_function_call_with_payment_name_ident(canister_id_principal, #(#param_names),* #payment_comma payment).await)
+                        _kybra_create_call_result_instance(vm, #cross_canister_function_call_with_payment_name_ident(canister_id_principal, #params, payment).await)
                     }
                 }
             })
@@ -285,13 +285,13 @@ fn generate_call_with_payment_match_arms(
 
 fn generate_call_with_payment128_match_arms(
     external_canisters: &Vec<ActExternalCanister>,
-) -> Vec<proc_macro2::TokenStream> {
+) -> Vec<TokenStream> {
     external_canisters
     .iter()
     .map(|act_external_canister| {
         let canister_name = &act_external_canister.name;
 
-        let arms: Vec<proc_macro2::TokenStream> = act_external_canister
+        let arms: Vec<TokenStream> = act_external_canister
             .methods
             .iter()
             .map(|act_external_canister_method| {
@@ -302,8 +302,8 @@ fn generate_call_with_payment128_match_arms(
 
                 let cross_canister_function_call_with_payment128_name_ident = format_ident!("{}", cross_canister_function_call_with_payment128_name);
 
-                let param_variable_definitions: Vec<proc_macro2::TokenStream> = act_external_canister_method.params.iter().enumerate().map(|(index, act_fn_param)| {
-                    let variable_name = format_ident!("_kybra_user_defined_var_{}", act_fn_param.name);
+                let param_variable_definitions: Vec<TokenStream> = act_external_canister_method.params.iter().enumerate().map(|(index, act_fn_param)| {
+                    let variable_name = format_ident!("{}", act_fn_param.prefixed_name());
                     let variable_type = act_fn_param.data_type.to_token_stream(&vec![]);
                     let actual_index = index + 2;
 
@@ -312,11 +312,11 @@ fn generate_call_with_payment128_match_arms(
                     }
                 }).collect();
 
-                let param_names: Vec<proc_macro2::Ident> = act_external_canister_method.params.iter().map(|act_fn_param| {
-                    format_ident!("_kybra_user_defined_var_{}", act_fn_param.name)
+                let param_names: Vec<Ident> = act_external_canister_method.params.iter().map(|act_fn_param| {
+                    format_ident!("{}", act_fn_param.prefixed_name())
                 }).collect();
+                let params = tuple::generate_tuple(&param_names);
 
-                let payment_comma = if act_external_canister_method.params.len() == 0 { quote! {} } else { quote! { , } };
                 let payment_index = act_external_canister_method.params.len() + 2;
                 let payment_variable_definition = quote!(let payment: u128 = args[#payment_index].clone().try_from_vm_value(vm).unwrap(););
 
@@ -327,7 +327,7 @@ fn generate_call_with_payment128_match_arms(
                         #(#param_variable_definitions)*
                         #payment_variable_definition
 
-                        _kybra_create_call_result_instance(vm, #cross_canister_function_call_with_payment128_name_ident(canister_id_principal, #(#param_names),* #payment_comma payment).await)
+                        _kybra_create_call_result_instance(vm, #cross_canister_function_call_with_payment128_name_ident(canister_id_principal, #params, payment).await)
                     }
                 }
             })

--- a/kybra/compiler/kybra_generate/src/generators/ic_object/functions/notify_functions.rs
+++ b/kybra/compiler/kybra_generate/src/generators/ic_object/functions/notify_functions.rs
@@ -16,8 +16,9 @@ pub fn generate_notify_functions(
             let real_function_name = format_ident!("{}", function_name_string);
             let wrapper_fn_name = format_ident!("{}_wrapper", function_name_string);
             let param_variable_definitions = generate_param_variables(method);
-            let param_names: Vec<proc_macro2::Ident> = method.params.iter().map(|param| {
-                format_ident!("{}", param.prefixed_name())
+            let param_names = method.params.iter().map(|param| {
+                let name = format_ident!("{}", param.prefixed_name());
+                quote!{#name}
             }).collect();
             let params = tuple::generate_tuple(&param_names);
 

--- a/kybra/compiler/kybra_generate/src/generators/ic_object/functions/notify_with_payment128_functions.rs
+++ b/kybra/compiler/kybra_generate/src/generators/ic_object/functions/notify_with_payment128_functions.rs
@@ -1,10 +1,11 @@
-use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
-
 use cdk_framework::{
     nodes::{ActExternalCanister, ActExternalCanisterMethod},
     ToTokenStream,
 };
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
+
+use crate::generators::tuple;
 
 pub fn generate_notify_with_payment128_functions(
     external_canisters: &Vec<ActExternalCanister>,
@@ -15,15 +16,10 @@ pub fn generate_notify_with_payment128_functions(
             let real_function_name = format_ident!("{}", function_name_string);
             let wrapper_fn_name = format_ident!("{}_wrapper", function_name_string);
             let param_variable_definitions = generate_param_variables(method);
-            let param_names: Vec<TokenStream> = method.params.iter().map(|param| {
-                let name = format_ident!("_kybra_user_defined_var_{}", param.name);
-                quote! { #name }
+            let param_names: Vec<Ident> = method.params.iter().map(|param| {
+                format_ident!("{}", param.prefixed_name())
             }).collect();
-            let comma = if param_names.len() == 0 {
-                quote! {}
-            } else {
-                quote! {,}
-            };
+            let params = tuple::generate_tuple(&param_names);
 
             quote!{
                 #[pymethod]
@@ -36,8 +32,7 @@ pub fn generate_notify_with_payment128_functions(
 
                     let notify_result = #real_function_name(
                         canister_id_principal,
-                        #(#param_names),*
-                        #comma
+                        #params,
                         cycles
                     );
 
@@ -50,7 +45,7 @@ pub fn generate_notify_with_payment128_functions(
 
 fn generate_param_variables(method: &ActExternalCanisterMethod) -> Vec<TokenStream> {
     method.params.iter().enumerate().map(|(index, act_fn_param)| {
-        let variable_name = format_ident!("_kybra_user_defined_var_{}", act_fn_param.name);
+        let variable_name = format_ident!("{}", act_fn_param.prefixed_name());
         let variable_type = act_fn_param.data_type.to_token_stream(&vec![]);
         let actual_index = index + 2;
 

--- a/kybra/compiler/kybra_generate/src/generators/ic_object/functions/notify_with_payment128_functions.rs
+++ b/kybra/compiler/kybra_generate/src/generators/ic_object/functions/notify_with_payment128_functions.rs
@@ -2,7 +2,7 @@ use cdk_framework::{
     nodes::{ActExternalCanister, ActExternalCanisterMethod},
     ToTokenStream,
 };
-use proc_macro2::{Ident, TokenStream};
+use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use crate::generators::tuple;
@@ -16,8 +16,9 @@ pub fn generate_notify_with_payment128_functions(
             let real_function_name = format_ident!("{}", function_name_string);
             let wrapper_fn_name = format_ident!("{}_wrapper", function_name_string);
             let param_variable_definitions = generate_param_variables(method);
-            let param_names: Vec<Ident> = method.params.iter().map(|param| {
-                format_ident!("{}", param.prefixed_name())
+            let param_names = method.params.iter().map(|param| {
+                let name = format_ident!("{}", param.prefixed_name());
+                quote!{ #name }
             }).collect();
             let params = tuple::generate_tuple(&param_names);
 

--- a/kybra/compiler/kybra_generate/src/generators/mod.rs
+++ b/kybra/compiler/kybra_generate/src/generators/mod.rs
@@ -1,4 +1,5 @@
 pub mod async_result_handler;
 pub mod ic_object;
 pub mod kybra_serde;
+pub mod tuple;
 pub mod vm_value_conversion;

--- a/kybra/compiler/kybra_generate/src/generators/tuple.rs
+++ b/kybra/compiler/kybra_generate/src/generators/tuple.rs
@@ -1,11 +1,11 @@
-use proc_macro2::{Ident, TokenStream};
+use proc_macro2::TokenStream;
 use quote::quote;
 
-pub fn generate_tuple(idents: &Vec<Ident>) -> TokenStream {
-    let comma = if idents.len() == 1 {
+pub fn generate_tuple(expressions: &Vec<TokenStream>) -> TokenStream {
+    let comma = if expressions.len() == 1 {
         quote! { , }
     } else {
         quote! {}
     };
-    quote! { (#(#idents),*#comma) }
+    quote! { (#(#expressions),*#comma) }
 }

--- a/kybra/compiler/kybra_generate/src/generators/tuple.rs
+++ b/kybra/compiler/kybra_generate/src/generators/tuple.rs
@@ -1,0 +1,11 @@
+use proc_macro2::{Ident, TokenStream};
+use quote::quote;
+
+pub fn generate_tuple(idents: &Vec<Ident>) -> TokenStream {
+    let comma = if idents.len() == 1 {
+        quote! { , }
+    } else {
+        quote! {}
+    };
+    quote! { (#(#idents),*#comma) }
+}

--- a/kybra/compiler/kybra_generate/src/py_ast/kybra_types/kybra_stmt/canister_method.rs
+++ b/kybra/compiler/kybra_generate/src/py_ast/kybra_types/kybra_stmt/canister_method.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use rustpython_parser::ast::{ExprKind, StmtKind};
 
-use crate::py_ast::kybra_types::KybraExpr;
+use crate::{generators::tuple, py_ast::kybra_types::KybraExpr};
 use cdk_framework::{
     nodes::{data_type_nodes::ActPrimitiveLit, ActFnParam},
     ActDataType, CanisterMethod, CanisterMethodType, ToActDataType,
@@ -116,25 +116,24 @@ impl KybraStmt<'_> {
     }
 
     fn generate_body(&self) -> TokenStream {
-        let params = self.build_act_params();
+        let act_params = self.build_act_params();
 
         let name = match self.get_name() {
             Some(name) => name,
             None => todo!(),
         };
 
-        let param_conversions = params.iter().map(|param| {
-            let param_name = format_ident!("{}", param.prefixed_name());
-            quote! {
-                #param_name.try_into_vm_value(vm).unwrap()
-            }
-        });
+        let param_conversions = act_params
+            .iter()
+            .map(|param| {
+                let name = format_ident!("{}", param.prefixed_name());
+                quote! {
+                    #name.try_into_vm_value(vm).unwrap()
+                }
+            })
+            .collect();
 
-        let params_comma = if param_conversions.len() == 1 {
-            quote!(,)
-        } else {
-            quote!()
-        };
+        let params = tuple::generate_tuple(&param_conversions);
 
         let return_expression = self.generate_return_expression();
 
@@ -147,7 +146,7 @@ impl KybraStmt<'_> {
 
                 let method_py_object_ref = _kybra_unwrap_rust_python_result(_kybra_scope.globals.get_item(#name, vm), vm);
 
-                let invoke_result = vm.invoke(&method_py_object_ref, (#(#param_conversions),*#params_comma));
+                let invoke_result = vm.invoke(&method_py_object_ref, #params);
 
                 match invoke_result {
                     Ok(py_object_ref) => {

--- a/kybra/compiler/kybra_generate/src/py_ast/kybra_types/kybra_stmt/system_methods/mod.rs
+++ b/kybra/compiler/kybra_generate/src/py_ast/kybra_types/kybra_stmt/system_methods/mod.rs
@@ -1,8 +1,11 @@
-use proc_macro2::{Ident, TokenStream};
+use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use super::KybraStmt;
-use crate::py_ast::{kybra_types::KybraExpr, what_is_it::WhatIsIt};
+use crate::{
+    generators::tuple,
+    py_ast::{kybra_types::KybraExpr, what_is_it::WhatIsIt},
+};
 use cdk_framework::{nodes::ActFnParam, ToActDataType};
 
 mod errors;
@@ -48,19 +51,18 @@ impl KybraStmt<'_> {
         match &self.stmt_kind.node {
             rustpython_parser::ast::StmtKind::FunctionDef { .. } => {
                 let function_name = self.get_function_name();
-                let params = self.build_params();
+                let act_params = self.build_params();
 
-                let param_conversions = params.iter().map(|act_fn_param| {
-                    let var = format_ident!("{}", act_fn_param.prefixed_name());
-                    quote! {
-                        #var.try_into_vm_value(vm).unwrap()
-                    }
-                });
-                let params_comma = if param_conversions.len() == 1 {
-                    quote!(,)
-                } else {
-                    quote!()
-                };
+                let param_conversions = act_params
+                    .iter()
+                    .map(|act_fn_param| {
+                        let name = format_ident!("{}", act_fn_param.prefixed_name());
+                        quote! {
+                            #name.try_into_vm_value(vm).unwrap()
+                        }
+                    })
+                    .collect();
+                let params = tuple::generate_tuple(&param_conversions);
 
                 quote! {
                     let _kybra_interpreter = _KYBRA_INTERPRETER_OPTION.as_mut().unwrap();
@@ -69,7 +71,7 @@ impl KybraStmt<'_> {
                     _kybra_interpreter.enter(|vm| {
                         let method_py_object_ref = _kybra_unwrap_rust_python_result(_kybra_scope.globals.get_item(#function_name, vm), vm);
 
-                        let result_py_object_ref = vm.invoke(&method_py_object_ref, (#(#param_conversions),*#params_comma));
+                        let result_py_object_ref = vm.invoke(&method_py_object_ref, #params);
 
                         match result_py_object_ref {
                             Ok(py_object_ref) => py_object_ref.try_from_vm_value(vm).unwrap(),

--- a/kybra/compiler/kybra_generate/src/py_ast/kybra_types/kybra_stmt/system_methods/mod.rs
+++ b/kybra/compiler/kybra_generate/src/py_ast/kybra_types/kybra_stmt/system_methods/mod.rs
@@ -27,7 +27,7 @@ impl KybraStmt<'_> {
                             None => panic!("{}", self.missing_type_annotation_error()),
                         };
                         ActFnParam {
-                            name: format!("_kybra_user_defined_var_{}", arg.node.arg.clone()),
+                            name: arg.node.arg.clone(),
                             data_type,
                         }
                     })
@@ -43,7 +43,7 @@ impl KybraStmt<'_> {
             rustpython_parser::ast::StmtKind::FunctionDef { args, .. } => args
                 .args
                 .iter()
-                .map(|arg| format_ident!("_kybra_user_defined_var_{}", arg.node.arg))
+                .map(|arg| format_ident!("{}", arg.node.arg))
                 .collect(),
             _ => panic!("{}", self.not_a_function_def_error()),
         }


### PR DESCRIPTION
Bumped CDK Framework to https://github.com/demergent-labs/cdk_framework/pull/14/commits/1147dd7dac981676b0b65b8e40f9a56fabb9bca2 and update the kybra side to match. This offloads the responsibility of marking user-defined variables to the CDK Framework.

Closes demergent-labs/azle#242