### PR TITLE
Fixed name collisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cdk_framework"
+version = "0.0.0"
+source = "git+https://github.com/demergent-labs/cdk_framework?rev=9ec378c8c577dad52249333aa04358221e6e0df0#9ec378c8c577dad52249333aa04358221e6e0df0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,7 +667,7 @@ dependencies = [
 name = "kybra-vm-value-derive"
 version = "0.0.0"
 dependencies = [
- "cdk_framework",
+ "cdk_framework 0.0.0 (git+https://github.com/demergent-labs/cdk_framework?rev=13c4abdd72bdcfa6a5b1ddf7f08a4fd83eacb419)",
  "proc-macro2",
  "quote",
  "syn 1.0.99",
@@ -668,7 +678,7 @@ name = "kybra_generate"
 version = "0.0.0"
 dependencies = [
  "annotate-snippets",
- "cdk_framework",
+ "cdk_framework 0.0.0 (git+https://github.com/demergent-labs/cdk_framework?rev=9ec378c8c577dad52249333aa04358221e6e0df0)",
  "num-bigint",
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,17 +72,7 @@ dependencies = [
 [[package]]
 name = "cdk_framework"
 version = "0.0.0"
-source = "git+https://github.com/demergent-labs/cdk_framework?rev=08a74a4077d0981acde2b0fc714e877bba659b9e#08a74a4077d0981acde2b0fc714e877bba659b9e"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
-]
-
-[[package]]
-name = "cdk_framework"
-version = "0.0.0"
-source = "git+https://github.com/demergent-labs/cdk_framework?rev=4993d8218acaa9102e4545fd9024e2008060d268#4993d8218acaa9102e4545fd9024e2008060d268"
+source = "git+https://github.com/demergent-labs/cdk_framework?rev=13c4abdd72bdcfa6a5b1ddf7f08a4fd83eacb419#13c4abdd72bdcfa6a5b1ddf7f08a4fd83eacb419"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -131,7 +121,7 @@ dependencies = [
 name = "kybra-vm-value-derive"
 version = "0.0.0"
 dependencies = [
- "cdk_framework 0.0.0 (git+https://github.com/demergent-labs/cdk_framework?rev=08a74a4077d0981acde2b0fc714e877bba659b9e)",
+ "cdk_framework",
  "proc-macro2",
  "quote",
  "syn",
@@ -142,7 +132,7 @@ name = "kybra_generate"
 version = "0.0.0"
 dependencies = [
  "annotate-snippets",
- "cdk_framework 0.0.0 (git+https://github.com/demergent-labs/cdk_framework?rev=4993d8218acaa9102e4545fd9024e2008060d268)",
+ "cdk_framework",
  "num-bigint",
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 [[package]]
 name = "cdk_framework"
 version = "0.0.0"
-source = "git+https://github.com/demergent-labs/cdk_framework?rev=61123bc8b4a94ae0fd80a4f710672d3cab3ca065#61123bc8b4a94ae0fd80a4f710672d3cab3ca065"
+source = "git+https://github.com/demergent-labs/cdk_framework?rev=4993d8218acaa9102e4545fd9024e2008060d268#4993d8218acaa9102e4545fd9024e2008060d268"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -142,7 +142,7 @@ name = "kybra_generate"
 version = "0.0.0"
 dependencies = [
  "annotate-snippets",
- "cdk_framework 0.0.0 (git+https://github.com/demergent-labs/cdk_framework?rev=61123bc8b4a94ae0fd80a4f710672d3cab3ca065)",
+ "cdk_framework 0.0.0 (git+https://github.com/demergent-labs/cdk_framework?rev=4993d8218acaa9102e4545fd9024e2008060d268)",
  "num-bigint",
  "proc-macro2",
  "quote",

--- a/kybra/__init__.py
+++ b/kybra/__init__.py
@@ -230,15 +230,15 @@ def get_first_frame(current_frame: Any) -> Any:
 class ic(Generic[T]):
     @staticmethod
     def accept_message():
-        _kybra_ic._kybra_accept_message()  # type: ignore
+        _kybra_ic.accept_message()  # type: ignore
 
     @staticmethod
     def arg_data_raw() -> blob:
-        return _kybra_ic._kybra_arg_data_raw()  # type: ignore
+        return _kybra_ic.arg_data_raw()  # type: ignore
 
     @staticmethod
     def arg_data_raw_size() -> nat32:
-        return _kybra_ic._kybra_arg_data_raw_size()  # type: ignore
+        return _kybra_ic.arg_data_raw_size()  # type: ignore
 
     @staticmethod
     def call_raw(
@@ -258,156 +258,156 @@ class ic(Generic[T]):
 
     @staticmethod
     def caller() -> Principal:
-        return _kybra_ic._kybra_caller()  # type: ignore
+        return _kybra_ic.caller()  # type: ignore
 
     @staticmethod
     def candid_encode(candid_string: str) -> blob:
-        return _kybra_ic._kybra_candid_encode(candid_string)  # type: ignore
+        return _kybra_ic.candid_encode(candid_string)  # type: ignore
 
     @staticmethod
     def candid_decode(candid_encoded: blob) -> str:
-        return _kybra_ic._kybra_candid_decode(candid_encoded)  # type: ignore
+        return _kybra_ic.candid_decode(candid_encoded)  # type: ignore
 
     @staticmethod
     def canister_balance() -> nat64:
-        return _kybra_ic._kybra_canister_balance()  # type: ignore
+        return _kybra_ic.canister_balance()  # type: ignore
 
     @staticmethod
     def canister_balance128() -> nat:
-        return _kybra_ic._kybra_canister_balance128()  # type: ignore
+        return _kybra_ic.canister_balance128()  # type: ignore
 
     @staticmethod
     def clear_timer(id: TimerId) -> None:
-        return _kybra_ic._kybra_clear_timer(id)  # type: ignore
+        return _kybra_ic.clear_timer(id)  # type: ignore
 
     @staticmethod
     def data_certificate() -> Opt[blob]:
-        return _kybra_ic._kybra_data_certificate()  # type: ignore
+        return _kybra_ic.data_certificate()  # type: ignore
 
     @staticmethod
     def id() -> Principal:
-        return _kybra_ic._kybra_id()  # type:ignore
+        return _kybra_ic.id()  # type:ignore
 
     @staticmethod
     def method_name() -> str:
-        return _kybra_ic._kybra_method_name()  # type:ignore
+        return _kybra_ic.method_name()  # type:ignore
 
     @staticmethod
     def msg_cycles_accept(max_amount: nat64) -> nat64:
-        return _kybra_ic._kybra_msg_cycles_accept(max_amount)  # type: ignore
+        return _kybra_ic.msg_cycles_accept(max_amount)  # type: ignore
 
     @staticmethod
     def msg_cycles_accept128(max_amount: nat) -> nat:
-        return _kybra_ic._kybra_msg_cycles_accept128(max_amount)  # type: ignore
+        return _kybra_ic.msg_cycles_accept128(max_amount)  # type: ignore
 
     @staticmethod
     def msg_cycles_available() -> nat64:
-        return _kybra_ic._kybra_msg_cycles_available()  # type: ignore
+        return _kybra_ic.msg_cycles_available()  # type: ignore
 
     @staticmethod
     def msg_cycles_available128() -> nat:
-        return _kybra_ic._kybra_msg_cycles_available128()  # type: ignore
+        return _kybra_ic.msg_cycles_available128()  # type: ignore
 
     @staticmethod
     def msg_cycles_refunded() -> nat64:
-        return _kybra_ic._kybra_msg_cycles_refunded()  # type: ignore
+        return _kybra_ic.msg_cycles_refunded()  # type: ignore
 
     @staticmethod
     def msg_cycles_refunded128() -> nat:
-        return _kybra_ic._kybra_msg_cycles_refunded128()  # type: ignore
+        return _kybra_ic.msg_cycles_refunded128()  # type: ignore
 
     @staticmethod
     def notify_raw(
         canister_id: Principal, method: str, args_raw: blob, payment: nat
     ) -> NotifyResult:
-        return _kybra_ic._kybra_notify_raw(  # type: ignore
+        return _kybra_ic.notify_raw(  # type: ignore
             canister_id, method, args_raw, payment
         )
 
     @staticmethod
     def performance_counter(counter_type: nat32) -> nat64:
-        return _kybra_ic._kybra_performance_counter(counter_type)  # type: ignore
+        return _kybra_ic.performance_counter(counter_type)  # type: ignore
 
     @staticmethod
     def print(x: Any):
-        _kybra_ic._kybra_print(str(x))  # type: ignore
+        _kybra_ic.print(str(x))  # type: ignore
 
     @staticmethod
     def reject(x: Any):
-        _kybra_ic._kybra_reject(x)  # type: ignore
+        _kybra_ic.reject(x)  # type: ignore
 
     @staticmethod
     def reject_code() -> RejectionCode:
-        return _kybra_ic._kybra_reject_code()  # type: ignore
+        return _kybra_ic.reject_code()  # type: ignore
 
     @staticmethod
     def reject_message() -> str:
-        return _kybra_ic._kybra_reject_message()  # type: ignore
+        return _kybra_ic.reject_message()  # type: ignore
 
     @staticmethod
     def reply(value: Any):
         first_called_function_name = get_first_called_function_name()
-        (_kybra_ic._kybra_reply(first_called_function_name, value))  # type: ignore
+        (_kybra_ic.reply(first_called_function_name, value))  # type: ignore
 
     @staticmethod
     def reply_raw(x: Any):
-        _kybra_ic._kybra_reply_raw(x)  # type: ignore
+        _kybra_ic.reply_raw(x)  # type: ignore
 
     @staticmethod
     def set_certified_data(data: blob):
-        _kybra_ic._kybra_set_certified_data(data)  # type: ignore
+        _kybra_ic.set_certified_data(data)  # type: ignore
 
     @staticmethod
     def set_timer(delay: Duration, func: Callable[[], Any]) -> TimerId:
-        return _kybra_ic._kybra_set_timer(delay, func)  # type: ignore
+        return _kybra_ic.set_timer(delay, func)  # type: ignore
 
     @staticmethod
     def set_timer_interval(interval: Duration, func: Callable[[], Any]) -> TimerId:
-        return _kybra_ic._kybra_set_timer_interval(interval, func)  # type: ignore
+        return _kybra_ic.set_timer_interval(interval, func)  # type: ignore
 
     @staticmethod
     def stable_bytes() -> blob:
-        return _kybra_ic._kybra_stable_bytes()  # type: ignore
+        return _kybra_ic.stable_bytes()  # type: ignore
 
     @staticmethod
     def stable_grow(new_pages: nat32) -> StableGrowResult:
-        return _kybra_ic._kybra_stable_grow(new_pages)  # type: ignore
+        return _kybra_ic.stable_grow(new_pages)  # type: ignore
 
     @staticmethod
     def stable_read(offset: nat32, length: nat32) -> blob:
-        return _kybra_ic._kybra_stable_read(offset, length)  # type: ignore
+        return _kybra_ic.stable_read(offset, length)  # type: ignore
 
     @staticmethod
     def stable_size() -> nat32:
-        return _kybra_ic._kybra_stable_size()  # type: ignore
+        return _kybra_ic.stable_size()  # type: ignore
 
     @staticmethod
     def stable_write(offset: nat32, buf: blob):
-        _kybra_ic._kybra_stable_write(offset, buf)  # type: ignore
+        _kybra_ic.stable_write(offset, buf)  # type: ignore
 
     @staticmethod
     def stable64_grow(new_pages: nat64) -> Stable64GrowResult:
-        return _kybra_ic._kybra_stable64_grow(new_pages)  # type: ignore
+        return _kybra_ic.stable64_grow(new_pages)  # type: ignore
 
     @staticmethod
     def stable64_read(offset: nat64, length: nat64) -> blob:
-        return _kybra_ic._kybra_stable64_read(offset, length)  # type: ignore
+        return _kybra_ic.stable64_read(offset, length)  # type: ignore
 
     @staticmethod
     def stable64_size() -> nat64:
-        return _kybra_ic._kybra_stable64_size()  # type: ignore
+        return _kybra_ic.stable64_size()  # type: ignore
 
     @staticmethod
     def stable64_write(offset: nat64, buf: blob):
-        _kybra_ic._kybra_stable64_write(offset, buf)  # type: ignore
+        _kybra_ic.stable64_write(offset, buf)  # type: ignore
 
     @staticmethod
     def time() -> nat64:
-        return _kybra_ic._kybra_time()  # type: ignore
+        return _kybra_ic.time()  # type: ignore
 
     @staticmethod
     def trap(message: str) -> NoReturn:  # type: ignore
-        _kybra_ic._kybra_trap(message)  # type: ignore
+        _kybra_ic.trap(message)  # type: ignore
 
 
 class Service:
@@ -507,7 +507,7 @@ class StableBTreeMap(Generic[K, V]):
         :param key: The key to check for in the map.
         :return: True if the key is in the map, False otherwise.
         """
-        return _kybra_ic._kybra_stable_b_tree_map_contains_key(self.memory_id, key)  # type: ignore
+        return _kybra_ic.stable_b_tree_map_contains_key(self.memory_id, key)  # type: ignore
 
     def get(self, key: K) -> Opt[V]:
         """
@@ -516,7 +516,7 @@ class StableBTreeMap(Generic[K, V]):
         :param key: The key to get the value for.
         :return: The value associated with the key, or None if the key is not in the map.
         """
-        return _kybra_ic._kybra_stable_b_tree_map_get(self.memory_id, key)  # type: ignore
+        return _kybra_ic.stable_b_tree_map_get(self.memory_id, key)  # type: ignore
 
     def insert(self, key: K, value: V) -> Opt[V]:
         """
@@ -530,7 +530,7 @@ class StableBTreeMap(Generic[K, V]):
         the err attribute will contain an instance of InsertError indicating the reason for the
         failure.
         """
-        return _kybra_ic._kybra_stable_b_tree_map_insert(self.memory_id, key, value)  # type: ignore
+        return _kybra_ic.stable_b_tree_map_insert(self.memory_id, key, value)  # type: ignore
 
     def is_empty(self) -> bool:
         """
@@ -538,7 +538,7 @@ class StableBTreeMap(Generic[K, V]):
 
         :return: True if the map is empty, False otherwise.
         """
-        return _kybra_ic._kybra_stable_b_tree_map_is_empty(self.memory_id)  # type: ignore
+        return _kybra_ic.stable_b_tree_map_is_empty(self.memory_id)  # type: ignore
 
     def items(self) -> Vec[Tuple[K, V]]:
         """
@@ -546,7 +546,7 @@ class StableBTreeMap(Generic[K, V]):
 
         :return: A list of tuples containing all key-value pairs in the map.
         """
-        return _kybra_ic._kybra_stable_b_tree_map_items(self.memory_id)  # type: ignore
+        return _kybra_ic.stable_b_tree_map_items(self.memory_id)  # type: ignore
 
     def keys(self) -> Vec[K]:
         """
@@ -554,7 +554,7 @@ class StableBTreeMap(Generic[K, V]):
 
         :return: A list of all keys in the map.
         """
-        return _kybra_ic._kybra_stable_b_tree_map_keys(self.memory_id)  # type: ignore
+        return _kybra_ic.stable_b_tree_map_keys(self.memory_id)  # type: ignore
 
     def len(self) -> nat64:
         """
@@ -562,7 +562,7 @@ class StableBTreeMap(Generic[K, V]):
 
         :return: The number of key-value pairs in the map.
         """
-        return _kybra_ic._kybra_stable_b_tree_map_len(self.memory_id)  # type: ignore
+        return _kybra_ic.stable_b_tree_map_len(self.memory_id)  # type: ignore
 
     def remove(self, key: K) -> Opt[V]:
         """
@@ -571,7 +571,7 @@ class StableBTreeMap(Generic[K, V]):
         :param key: The key of the key-value pair to remove.
         :return: The value associated with the key, or None if the key is not in the map.
         """
-        return _kybra_ic._kybra_stable_b_tree_map_remove(self.memory_id, key)  # type: ignore
+        return _kybra_ic.stable_b_tree_map_remove(self.memory_id, key)  # type: ignore
 
     def values(self) -> Vec[V]:
         """
@@ -579,7 +579,7 @@ class StableBTreeMap(Generic[K, V]):
 
         :return: A list of all values in the map.
         """
-        return _kybra_ic._kybra_stable_b_tree_map_values(self.memory_id)  # type: ignore
+        return _kybra_ic.stable_b_tree_map_values(self.memory_id)  # type: ignore
 
 
 def match(

--- a/kybra/__init__.py
+++ b/kybra/__init__.py
@@ -442,7 +442,7 @@ class AsyncInfo:
             else ""
         )
         notify_function_name = (
-            f'_kybra_notify_{with_payment}{qualname.replace(".", "_")}_wrapper'
+            f'notify_{with_payment}{qualname.replace(".", "_")}_wrapper'
         )
 
         return getattr(_kybra_ic, notify_function_name)(self.args)  # type: ignore

--- a/kybra/candid.py
+++ b/kybra/candid.py
@@ -162,7 +162,7 @@ def generate_candid_file(paths) -> str:
 
     instance = Instance(module, import_object)
 
-    candid_pointer = instance.exports._cdk_get_candid_pointer()
+    candid_pointer = instance.exports.get_candid_pointer()
 
     memory = instance.exports.memory.uint8_view()
     string_bytes = []

--- a/kybra/compiler/kybra_generate/Cargo.toml
+++ b/kybra/compiler/kybra_generate/Cargo.toml
@@ -12,7 +12,7 @@ rustpython-parser = { git = "https://github.com/demergent-labs/RustPython", bran
 annotate-snippets = "0.9.1"
 num-bigint = "0.4.3"
 # rustpython = { path = "../../../../RustPython", default-features = false, features = [] }
-cdk_framework = { git = "https://github.com/demergent-labs/cdk_framework", rev = "61123bc8b4a94ae0fd80a4f710672d3cab3ca065" }
+cdk_framework = { git = "https://github.com/demergent-labs/cdk_framework", rev = "4993d8218acaa9102e4545fd9024e2008060d268" }
 # cdk_framework = { path = "path/to/local/cdk_framework" }
 # For local rust-analyzer uncomment this line and comment out the line above.
 # Update path/to/local to be the path to your local cdk_framework repo

--- a/kybra/compiler/kybra_generate/Cargo.toml
+++ b/kybra/compiler/kybra_generate/Cargo.toml
@@ -12,7 +12,7 @@ rustpython-parser = { git = "https://github.com/demergent-labs/RustPython", bran
 annotate-snippets = "0.9.1"
 num-bigint = "0.4.3"
 # rustpython = { path = "../../../../RustPython", default-features = false, features = [] }
-cdk_framework = { git = "https://github.com/demergent-labs/cdk_framework", rev = "13c4abdd72bdcfa6a5b1ddf7f08a4fd83eacb419" }
+cdk_framework = { git = "https://github.com/demergent-labs/cdk_framework", rev = "9ec378c8c577dad52249333aa04358221e6e0df0" }
 # cdk_framework = { path = "path/to/local/cdk_framework" }
 # For local rust-analyzer uncomment this line and comment out the line above.
 # Update path/to/local to be the path to your local cdk_framework repo

--- a/kybra/compiler/kybra_generate/Cargo.toml
+++ b/kybra/compiler/kybra_generate/Cargo.toml
@@ -12,7 +12,7 @@ rustpython-parser = { git = "https://github.com/demergent-labs/RustPython", bran
 annotate-snippets = "0.9.1"
 num-bigint = "0.4.3"
 # rustpython = { path = "../../../../RustPython", default-features = false, features = [] }
-cdk_framework = { git = "https://github.com/demergent-labs/cdk_framework", rev = "4993d8218acaa9102e4545fd9024e2008060d268" }
+cdk_framework = { git = "https://github.com/demergent-labs/cdk_framework", rev = "13c4abdd72bdcfa6a5b1ddf7f08a4fd83eacb419" }
 # cdk_framework = { path = "path/to/local/cdk_framework" }
 # For local rust-analyzer uncomment this line and comment out the line above.
 # Update path/to/local to be the path to your local cdk_framework repo

--- a/kybra/compiler/kybra_generate/src/async_result_handler.rs
+++ b/kybra/compiler/kybra_generate/src/async_result_handler.rs
@@ -14,38 +14,38 @@ pub fn generate(services: &Vec<Service>) -> TokenStream {
 
     quote! {
         #[async_recursion::async_recursion(?Send)]
-        async fn _kybra_async_result_handler(
+        async fn async_result_handler(
             vm: &rustpython::vm::VirtualMachine,
             py_object_ref: &rustpython::vm::PyObjectRef,
             arg: rustpython_vm::PyObjectRef
         ) -> rustpython::vm::PyObjectRef {
-            if _kybra_is_generator(vm, &py_object_ref) == false {
+            if is_generator(vm, &py_object_ref) == false {
                 return py_object_ref.clone();
             }
 
             let send_result = vm.call_method(&py_object_ref, "send", (arg.clone(),));
-            let py_iter_return = _kybra_unwrap_rust_python_result(
+            let py_iter_return = unwrap_rust_python_result(
                 rustpython_vm::protocol::PyIterReturn::from_pyresult(send_result, vm),
                 vm
             );
 
             match py_iter_return {
                 rustpython_vm::protocol::PyIterReturn::Return(returned_py_object_ref) => {
-                    if _kybra_is_generator(vm, &returned_py_object_ref) == true {
-                        let recursed_py_object_ref = _kybra_async_result_handler(vm, &returned_py_object_ref, vm.ctx.none()).await;
+                    if is_generator(vm, &returned_py_object_ref) == true {
+                        let recursed_py_object_ref = async_result_handler(vm, &returned_py_object_ref, vm.ctx.none()).await;
 
-                        return _kybra_async_result_handler(vm, py_object_ref, recursed_py_object_ref).await;
+                        return async_result_handler(vm, py_object_ref, recursed_py_object_ref).await;
                     }
 
-                    let name: String = _kybra_unwrap_rust_python_result(returned_py_object_ref.get_attr("name", vm), vm).try_from_vm_value(vm).unwrap();
-                    let args: Vec<rustpython_vm::PyObjectRef> = _kybra_unwrap_rust_python_result(_kybra_unwrap_rust_python_result(returned_py_object_ref.get_attr("args", vm), vm).try_into_value(vm), vm);
+                    let name: String = unwrap_rust_python_result(returned_py_object_ref.get_attr("name", vm), vm).try_from_vm_value(vm).unwrap();
+                    let args: Vec<rustpython_vm::PyObjectRef> = unwrap_rust_python_result(unwrap_rust_python_result(returned_py_object_ref.get_attr("args", vm), vm).try_into_value(vm), vm);
 
                     match &name[..] {
-                        "call" => _kybra_async_result_handler_call(vm, py_object_ref, &args).await,
-                        "call_with_payment" => _kybra_async_result_handler_call_with_payment(vm, py_object_ref, &args).await,
-                        "call_with_payment128" => _kybra_async_result_handler_call_with_payment128(vm, py_object_ref, &args).await,
-                        "call_raw" => _kybra_async_result_handler_call_raw(vm, py_object_ref, &args).await,
-                        "call_raw128" => _kybra_async_result_handler_call_raw128(vm, py_object_ref, &args).await,
+                        "call" => async_result_handler_call(vm, py_object_ref, &args).await,
+                        "call_with_payment" => async_result_handler_call_with_payment(vm, py_object_ref, &args).await,
+                        "call_with_payment128" => async_result_handler_call_with_payment128(vm, py_object_ref, &args).await,
+                        "call_raw" => async_result_handler_call_raw(vm, py_object_ref, &args).await,
+                        "call_raw128" => async_result_handler_call_raw128(vm, py_object_ref, &args).await,
                         _ => panic!("async operation not supported")
                     }
                 },
@@ -57,7 +57,7 @@ pub fn generate(services: &Vec<Service>) -> TokenStream {
         }
 
         // TODO do this more officially, check if py_object_ref instanceof generator type
-        fn _kybra_is_generator(
+        fn is_generator(
             vm: &rustpython::vm::VirtualMachine,
             py_object_ref: &rustpython_vm::PyObjectRef
         ) -> bool {
@@ -69,7 +69,7 @@ pub fn generate(services: &Vec<Service>) -> TokenStream {
             }
         }
 
-        async fn _kybra_async_result_handler_call(
+        async fn async_result_handler_call(
             vm: &rustpython::vm::VirtualMachine,
             py_object_ref: &rustpython_vm::PyObjectRef,
             args: &Vec<rustpython_vm::PyObjectRef>
@@ -77,17 +77,17 @@ pub fn generate(services: &Vec<Service>) -> TokenStream {
             let canister_id_principal: ic_cdk::export::Principal = args[0].clone().try_from_vm_value(vm).unwrap();
             let qualname: String = args[1].clone().try_from_vm_value(vm).unwrap();
 
-            let cross_canister_call_function_name = format!("_kybra_call_{}", qualname.replace(".", "_"));
+            let cross_canister_call_function_name = format!("call_{}", qualname.replace(".", "_"));
 
             let call_result_instance = match &cross_canister_call_function_name[..] {
                 #(#call_match_arms),*
                 _ => panic!("cross canister function does not exist")
             };
 
-            _kybra_async_result_handler(vm, py_object_ref, call_result_instance).await
+            async_result_handler(vm, py_object_ref, call_result_instance).await
         }
 
-        async fn _kybra_async_result_handler_call_with_payment(
+        async fn async_result_handler_call_with_payment(
             vm: &rustpython::vm::VirtualMachine,
             py_object_ref: &rustpython_vm::PyObjectRef,
             args: &Vec<rustpython_vm::PyObjectRef>
@@ -95,17 +95,17 @@ pub fn generate(services: &Vec<Service>) -> TokenStream {
             let canister_id_principal: ic_cdk::export::Principal = args[0].clone().try_from_vm_value(vm).unwrap();
             let qualname: String = args[1].clone().try_from_vm_value(vm).unwrap();
 
-            let cross_canister_call_with_payment_function_name = format!("_kybra_call_with_payment_{}", qualname.replace(".", "_"));
+            let cross_canister_call_with_payment_function_name = format!("call_with_payment_{}", qualname.replace(".", "_"));
 
             let call_result_instance = match &cross_canister_call_with_payment_function_name[..] {
                 #(#call_with_payment_match_arms),*
                 _ => panic!("cross canister function does not exist")
             };
 
-            _kybra_async_result_handler(vm, py_object_ref, call_result_instance).await
+            async_result_handler(vm, py_object_ref, call_result_instance).await
         }
 
-        async fn _kybra_async_result_handler_call_with_payment128(
+        async fn async_result_handler_call_with_payment128(
             vm: &rustpython::vm::VirtualMachine,
             py_object_ref: &rustpython_vm::PyObjectRef,
             args: &Vec<rustpython_vm::PyObjectRef>
@@ -113,17 +113,17 @@ pub fn generate(services: &Vec<Service>) -> TokenStream {
             let canister_id_principal: ic_cdk::export::Principal = args[0].clone().try_from_vm_value(vm).unwrap();
             let qualname: String = args[1].clone().try_from_vm_value(vm).unwrap();
 
-            let cross_canister_call_with_payment128_function_name = format!("_kybra_call_with_payment128_{}", qualname.replace(".", "_"));
+            let cross_canister_call_with_payment128_function_name = format!("call_with_payment128_{}", qualname.replace(".", "_"));
 
             let call_result_instance = match &cross_canister_call_with_payment128_function_name[..] {
                 #(#call_with_payment128_match_arms),*
                 _ => panic!("cross canister function does not exist")
             };
 
-            _kybra_async_result_handler(vm, py_object_ref, call_result_instance).await
+            async_result_handler(vm, py_object_ref, call_result_instance).await
         }
 
-        async fn _kybra_async_result_handler_call_raw(
+        async fn async_result_handler_call_raw(
             vm: &rustpython::vm::VirtualMachine,
             py_object_ref: &rustpython_vm::PyObjectRef,
             args: &Vec<rustpython_vm::PyObjectRef>
@@ -140,10 +140,10 @@ pub fn generate(services: &Vec<Service>) -> TokenStream {
                 payment
             ).await;
 
-            _kybra_async_result_handler(vm, py_object_ref, _kybra_create_call_result_instance(vm, call_raw_result)).await
+            async_result_handler(vm, py_object_ref, create_call_result_instance(vm, call_raw_result)).await
         }
 
-        async fn _kybra_async_result_handler_call_raw128(
+        async fn async_result_handler_call_raw128(
             vm: &rustpython::vm::VirtualMachine,
             py_object_ref: &rustpython_vm::PyObjectRef,
             args: &Vec<rustpython_vm::PyObjectRef>
@@ -160,16 +160,16 @@ pub fn generate(services: &Vec<Service>) -> TokenStream {
                 payment
             ).await;
 
-            _kybra_async_result_handler(vm, py_object_ref, _kybra_create_call_result_instance(vm, call_raw_result)).await
+            async_result_handler(vm, py_object_ref, create_call_result_instance(vm, call_raw_result)).await
         }
 
-        fn _kybra_create_call_result_instance<T>(
+        fn create_call_result_instance<T>(
             vm: &rustpython::vm::VirtualMachine,
             call_result: ic_cdk::api::call::CallResult<T>
         ) -> rustpython_vm::PyObjectRef
             where T: for<'a> CdkActTryIntoVmValue<&'a rustpython::vm::VirtualMachine, rustpython::vm::PyObjectRef>
         {
-            let call_result_class = _kybra_unwrap_rust_python_result(vm.run_block_expr(
+            let call_result_class = unwrap_rust_python_result(vm.run_block_expr(
                 vm.new_scope_with_builtins(),
                 r#"
 from kybra import CallResult
@@ -182,7 +182,7 @@ CallResult
                 Ok(ok) => {
                     let method_result = vm.invoke(&call_result_class, (ok.try_into_vm_value(vm).unwrap(), vm.ctx.none()));
 
-                    _kybra_unwrap_rust_python_result(method_result, vm)
+                    unwrap_rust_python_result(method_result, vm)
 
                     // TODO Consider using dict once we are on Python 3.11: https://github.com/python/cpython/issues/89026
                     // let dict = vm.ctx.new_dict();
@@ -196,7 +196,7 @@ CallResult
 
                     let method_result = vm.invoke(&call_result_class, (vm.ctx.none(), err_string.try_into_vm_value(vm).unwrap()));
 
-                    _kybra_unwrap_rust_python_result(method_result, vm)
+                    unwrap_rust_python_result(method_result, vm)
 
                     // TODO Consider using dict once we are on Python 3.11: https://github.com/python/cpython/issues/89026
                     // let dict = vm.ctx.new_dict();
@@ -221,7 +221,7 @@ fn generate_call_match_arms(services: &Vec<Service>) -> Vec<TokenStream> {
             .iter()
             .map(|method| {
                 let cross_canister_function_call_name = format!(
-                    "_kybra_call_{}_{}",
+                    "call_{}_{}",
                     canister_name, method.name
                 );
 
@@ -254,7 +254,7 @@ fn generate_call_match_arms(services: &Vec<Service>) -> Vec<TokenStream> {
 
                         #(#param_variable_definitions)*
 
-                        _kybra_create_call_result_instance(vm, #cross_canister_function_call_name_ident(canister_id_principal, #params).await)
+                        create_call_result_instance(vm, #cross_canister_function_call_name_ident(canister_id_principal, #params).await)
                     }
                 }
             })
@@ -278,7 +278,7 @@ fn generate_call_with_payment_match_arms(services: &Vec<Service>) -> Vec<TokenSt
             .iter()
             .map(|method| {
                 let cross_canister_function_call_with_payment_name = format!(
-                    "_kybra_call_with_payment_{}_{}",
+                    "call_with_payment_{}_{}",
                     canister_name, method.name
                 );
 
@@ -315,7 +315,7 @@ fn generate_call_with_payment_match_arms(services: &Vec<Service>) -> Vec<TokenSt
                         #(#param_variable_definitions)*
                         #payment_variable_definition
 
-                        _kybra_create_call_result_instance(vm, #cross_canister_function_call_with_payment_name_ident(canister_id_principal, #params, payment).await)
+                        create_call_result_instance(vm, #cross_canister_function_call_with_payment_name_ident(canister_id_principal, #params, payment).await)
                     }
                 }
             })
@@ -339,7 +339,7 @@ fn generate_call_with_payment128_match_arms(services: &Vec<Service>) -> Vec<Toke
             .iter()
             .map(|method| {
                 let cross_canister_function_call_with_payment128_name = format!(
-                    "_kybra_call_with_payment128_{}_{}",
+                    "call_with_payment128_{}_{}",
                     canister_name, method.name
                 );
 
@@ -376,7 +376,7 @@ fn generate_call_with_payment128_match_arms(services: &Vec<Service>) -> Vec<Toke
                         #(#param_variable_definitions)*
                         #payment_variable_definition
 
-                        _kybra_create_call_result_instance(vm, #cross_canister_function_call_with_payment128_name_ident(canister_id_principal, #params, payment).await)
+                        create_call_result_instance(vm, #cross_canister_function_call_with_payment128_name_ident(canister_id_principal, #params, payment).await)
                     }
                 }
             })

--- a/kybra/compiler/kybra_generate/src/candid_type/service/rust.rs
+++ b/kybra/compiler/kybra_generate/src/candid_type/service/rust.rs
@@ -9,9 +9,9 @@ pub fn to_vm_value(name: String) -> TokenStream {
         impl CdkActTryIntoVmValue<&rustpython::vm::VirtualMachine, rustpython::vm::PyObjectRef> for #service_name {
             fn try_into_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<rustpython::vm::PyObjectRef, CdkActTryIntoVmValueError> {
                 unsafe {
-                    let vm_scope = VM_SCOPE.clone().unwrap();
+                    let scope = SCOPE_OPTION.clone().unwrap();
                     Ok(unwrap_rust_python_result(vm.run_block_expr(
-                        vm_scope, format!(
+                        scope, format!(
 r#"
 from kybra import Principal
 {}(Principal.from_str('{}'))

--- a/kybra/compiler/kybra_generate/src/candid_type/service/rust.rs
+++ b/kybra/compiler/kybra_generate/src/candid_type/service/rust.rs
@@ -9,9 +9,9 @@ pub fn to_vm_value(name: String) -> TokenStream {
         impl CdkActTryIntoVmValue<&rustpython::vm::VirtualMachine, rustpython::vm::PyObjectRef> for #service_name {
             fn try_into_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<rustpython::vm::PyObjectRef, CdkActTryIntoVmValueError> {
                 unsafe {
-                    let _kybra_scope = _KYBRA_SCOPE_OPTION.clone().unwrap();
-                    Ok(_kybra_unwrap_rust_python_result(vm.run_block_expr(
-                        _kybra_scope, format!(
+                    let vm_scope = VM_SCOPE.clone().unwrap();
+                    Ok(unwrap_rust_python_result(vm.run_block_expr(
+                        vm_scope, format!(
 r#"
 from kybra import Principal
 {}(Principal.from_str('{}'))
@@ -38,10 +38,10 @@ pub fn from_vm_value(name: String) -> TokenStream {
     quote! {
         impl CdkActTryFromVmValue<#service_name, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<#service_name, CdkActTryFromVmValueError> {
-                let canister_id = _kybra_unwrap_rust_python_result(self.get_attr("canister_id", vm), vm);
-                let to_str = _kybra_unwrap_rust_python_result(canister_id.get_attr("to_str", vm), vm);
-                let result = _kybra_unwrap_rust_python_result(vm.invoke(&to_str, ()), vm);
-                let result_string: String = _kybra_unwrap_rust_python_result(result.try_into_value(vm), vm);
+                let canister_id = unwrap_rust_python_result(self.get_attr("canister_id", vm), vm);
+                let to_str = unwrap_rust_python_result(canister_id.get_attr("to_str", vm), vm);
+                let result = unwrap_rust_python_result(vm.invoke(&to_str, ()), vm);
+                let result_string: String = unwrap_rust_python_result(result.try_into_value(vm), vm);
 
                 Ok(#service_name::new(ic_cdk::export::Principal::from_str(&result_string).unwrap()))
             }

--- a/kybra/compiler/kybra_generate/src/canister_method/heartbeat_method/rust.rs
+++ b/kybra/compiler/kybra_generate/src/canister_method/heartbeat_method/rust.rs
@@ -12,17 +12,17 @@ pub fn generate(
     Ok(quote! {
         unsafe {
             ic_cdk::spawn(async {
-                let _kybra_interpreter = _KYBRA_INTERPRETER_OPTION.as_mut().unwrap();
-                let _kybra_scope = _KYBRA_SCOPE_OPTION.as_mut().unwrap();
+                let vm_interpreter = VM_INTERPRETER_OPTION.as_mut().unwrap();
+                let vm_scope = VM_SCOPE.as_mut().unwrap();
 
-                let vm = &_kybra_interpreter.vm;
+                let vm = &vm_interpreter.vm;
 
-                let method_py_object_ref = _kybra_unwrap_rust_python_result(_kybra_scope.globals.get_item(#function_name, vm), vm);
+                let method_py_object_ref = unwrap_rust_python_result(vm_scope.globals.get_item(#function_name, vm), vm);
 
                 let result_py_object_ref = vm.invoke(&method_py_object_ref, ());
 
                 match result_py_object_ref {
-                    Ok(py_object_ref) => _kybra_async_result_handler(vm, &py_object_ref, vm.ctx.none()).await,
+                    Ok(py_object_ref) => async_result_handler(vm, &py_object_ref, vm.ctx.none()).await,
                     Err(err) => {
                         let err_string: String = err.to_pyobject(vm).repr(vm).unwrap().to_string();
 

--- a/kybra/compiler/kybra_generate/src/canister_method/heartbeat_method/rust.rs
+++ b/kybra/compiler/kybra_generate/src/canister_method/heartbeat_method/rust.rs
@@ -12,12 +12,12 @@ pub fn generate(
     Ok(quote! {
         unsafe {
             ic_cdk::spawn(async {
-                let vm_interpreter = VM_INTERPRETER_OPTION.as_mut().unwrap();
-                let vm_scope = VM_SCOPE.as_mut().unwrap();
+                let interpreter = INTERPRETER_OPTION.as_mut().unwrap();
+                let scope = SCOPE_OPTION.as_mut().unwrap();
 
-                let vm = &vm_interpreter.vm;
+                let vm = &interpreter.vm;
 
-                let method_py_object_ref = unwrap_rust_python_result(vm_scope.globals.get_item(#function_name, vm), vm);
+                let method_py_object_ref = unwrap_rust_python_result(scope.globals.get_item(#function_name, vm), vm);
 
                 let result_py_object_ref = vm.invoke(&method_py_object_ref, ());
 

--- a/kybra/compiler/kybra_generate/src/canister_method/init_method/rust.rs
+++ b/kybra/compiler/kybra_generate/src/canister_method/init_method/rust.rs
@@ -15,21 +15,21 @@ pub fn generate(
 
     Ok(quote! {
         unsafe {
-            let _kybra_interpreter = rustpython_vm::Interpreter::with_init(Default::default(), |vm| {
+            let vm_interpreter = rustpython_vm::Interpreter::with_init(Default::default(), |vm| {
                 // TODO add this back once we support the full stdlib: https://github.com/demergent-labs/kybra/issues/12
                 // vm.add_frozen(rustpython_pylib::frozen_stdlib());
                 vm.add_native_modules(rustpython_stdlib::get_module_inits());
                 vm.add_frozen(rustpython_vm::py_freeze!(dir = "python_source"));
             });
-            let _kybra_scope = _kybra_interpreter.enter(|vm| vm.new_scope_with_builtins());
+            let vm_scope = vm_interpreter.enter(|vm| vm.new_scope_with_builtins());
 
-            _kybra_interpreter.enter(|vm| {
+            vm_interpreter.enter(|vm| {
                 Ic::make_class(&vm.ctx);
-                _kybra_unwrap_rust_python_result(vm.builtins.set_attr("_kybra_ic", vm.new_pyobj(Ic {}), vm), vm);
+                unwrap_rust_python_result(vm.builtins.set_attr("_kybra_ic", vm.new_pyobj(Ic {}), vm), vm);
 
 
                 let result = vm.run_code_string(
-                    _kybra_scope.clone(),
+                    vm_scope.clone(),
                     &format!("from {} import *", #entry_module_name),
                     "".to_owned(),
                 );
@@ -41,8 +41,8 @@ pub fn generate(
                 }
             });
 
-            _KYBRA_INTERPRETER_OPTION = Some(_kybra_interpreter);
-            _KYBRA_SCOPE_OPTION = Some(_kybra_scope);
+            VM_INTERPRETER_OPTION = Some(vm_interpreter);
+            VM_SCOPE = Some(vm_scope);
 
             #call_to_init_py_function
 

--- a/kybra/compiler/kybra_generate/src/canister_method/init_method/rust.rs
+++ b/kybra/compiler/kybra_generate/src/canister_method/init_method/rust.rs
@@ -46,7 +46,7 @@ pub fn generate(
 
             #call_to_init_py_function
 
-            ic_cdk_timers::set_timer(core::time::Duration::new(0, 0), _cdk_rng_seed);
+            ic_cdk_timers::set_timer(core::time::Duration::new(0, 0), rng_seed);
         }
     })
 }

--- a/kybra/compiler/kybra_generate/src/canister_method/inspect_message_method/rust.rs
+++ b/kybra/compiler/kybra_generate/src/canister_method/inspect_message_method/rust.rs
@@ -11,10 +11,10 @@ pub fn generate(
 
     Ok(quote::quote! {
         unsafe {
-            let _kybra_interpreter = _KYBRA_INTERPRETER_OPTION.as_mut().unwrap();
-            let _kybra_scope = _KYBRA_SCOPE_OPTION.as_mut().unwrap();
+            let vm_interpreter = VM_INTERPRETER_OPTION.as_mut().unwrap();
+            let vm_scope = VM_SCOPE.as_mut().unwrap();
 
-            _kybra_interpreter.enter(|vm| {
+            vm_interpreter.enter(|vm| {
                 #call_to_inspect_message_py_function
             });
         }

--- a/kybra/compiler/kybra_generate/src/canister_method/inspect_message_method/rust.rs
+++ b/kybra/compiler/kybra_generate/src/canister_method/inspect_message_method/rust.rs
@@ -12,15 +12,15 @@ pub fn generate(
     Ok(quote::quote! {
         unsafe {
             // TODO is this a security vulnerability?
-            if VM_INTERPRETER_OPTION.is_none() {
+            if INTERPRETER_OPTION.is_none() {
                 ic_cdk::api::call::accept_message();
                 return;
             }
 
-            let vm_interpreter = VM_INTERPRETER_OPTION.as_mut().unwrap();
-            let vm_scope = VM_SCOPE.as_mut().unwrap();
+            let interpreter = INTERPRETER_OPTION.as_mut().unwrap();
+            let scope = SCOPE_OPTION.as_mut().unwrap();
 
-            vm_interpreter.enter(|vm| {
+            interpreter.enter(|vm| {
                 #call_to_inspect_message_py_function
             });
         }

--- a/kybra/compiler/kybra_generate/src/canister_method/post_upgrade_method/rust.rs
+++ b/kybra/compiler/kybra_generate/src/canister_method/post_upgrade_method/rust.rs
@@ -47,7 +47,7 @@ pub fn generate(
 
             #call_to_post_upgrade_py_function
 
-            ic_cdk_timers::set_timer(core::time::Duration::new(0, 0), _cdk_rng_seed);
+            ic_cdk_timers::set_timer(core::time::Duration::new(0, 0), rng_seed);
         }
     })
 }

--- a/kybra/compiler/kybra_generate/src/canister_method/post_upgrade_method/rust.rs
+++ b/kybra/compiler/kybra_generate/src/canister_method/post_upgrade_method/rust.rs
@@ -17,20 +17,20 @@ pub fn generate(
 
     Ok(quote! {
         unsafe {
-            let _kybra_interpreter = rustpython_vm::Interpreter::with_init(Default::default(), |vm| {
+            let vm_interpreter = rustpython_vm::Interpreter::with_init(Default::default(), |vm| {
                 // TODO add this back once we support the full stdlib: https://github.com/demergent-labs/kybra/issues/12
                 // vm.add_frozen(rustpython_pylib::frozen_stdlib());
                 vm.add_native_modules(rustpython_stdlib::get_module_inits());
                 vm.add_frozen(rustpython_vm::py_freeze!(dir = "python_source"));
             });
-            let _kybra_scope = _kybra_interpreter.enter(|vm| vm.new_scope_with_builtins());
+            let vm_scope = vm_interpreter.enter(|vm| vm.new_scope_with_builtins());
 
-            _kybra_interpreter.enter(|vm| {
+            vm_interpreter.enter(|vm| {
                 Ic::make_class(&vm.ctx);
-                _kybra_unwrap_rust_python_result(vm.builtins.set_attr("_kybra_ic", vm.new_pyobj(Ic {}), vm), vm);
+                unwrap_rust_python_result(vm.builtins.set_attr("_kybra_ic", vm.new_pyobj(Ic {}), vm), vm);
 
                 let result = vm.run_code_string(
-                    _kybra_scope.clone(),
+                    vm_scope.clone(),
                     &format!("from {} import *", #entry_module_name),
                     "".to_owned(),
                 );
@@ -42,8 +42,8 @@ pub fn generate(
                 }
             });
 
-            _KYBRA_INTERPRETER_OPTION = Some(_kybra_interpreter);
-            _KYBRA_SCOPE_OPTION = Some(_kybra_scope);
+            VM_INTERPRETER_OPTION = Some(vm_interpreter);
+            VM_SCOPE = Some(vm_scope);
 
             #call_to_post_upgrade_py_function
 

--- a/kybra/compiler/kybra_generate/src/canister_method/pre_upgrade_method/rust.rs
+++ b/kybra/compiler/kybra_generate/src/canister_method/pre_upgrade_method/rust.rs
@@ -12,10 +12,10 @@ pub fn generate(
 
     Ok(quote! {
         unsafe {
-            let vm_interpreter = VM_INTERPRETER_OPTION.as_mut().unwrap();
-            let vm_scope = VM_SCOPE.as_mut().unwrap();
+            let interpreter = INTERPRETER_OPTION.as_mut().unwrap();
+            let scope = SCOPE_OPTION.as_mut().unwrap();
 
-            vm_interpreter.enter(|vm| {
+            interpreter.enter(|vm| {
                 #call_to_pre_upgrade_py_function
             });
         }

--- a/kybra/compiler/kybra_generate/src/canister_method/pre_upgrade_method/rust.rs
+++ b/kybra/compiler/kybra_generate/src/canister_method/pre_upgrade_method/rust.rs
@@ -12,10 +12,10 @@ pub fn generate(
 
     Ok(quote! {
         unsafe {
-            let _kybra_interpreter = _KYBRA_INTERPRETER_OPTION.as_mut().unwrap();
-            let _kybra_scope = _KYBRA_SCOPE_OPTION.as_mut().unwrap();
+            let vm_interpreter = VM_INTERPRETER_OPTION.as_mut().unwrap();
+            let vm_scope = VM_SCOPE.as_mut().unwrap();
 
-            _kybra_interpreter.enter(|vm| {
+            vm_interpreter.enter(|vm| {
                 #call_to_pre_upgrade_py_function
             });
         }

--- a/kybra/compiler/kybra_generate/src/canister_method/query_or_update/rust.rs
+++ b/kybra/compiler/kybra_generate/src/canister_method/query_or_update/rust.rs
@@ -33,12 +33,12 @@ pub fn generate_body(
 
     Ok(quote! {
         unsafe {
-            let vm_interpreter = VM_INTERPRETER_OPTION.as_mut().unwrap();
-            let vm_scope = VM_SCOPE.as_mut().unwrap();
+            let interpreter = INTERPRETER_OPTION.as_mut().unwrap();
+            let scope = SCOPE_OPTION.as_mut().unwrap();
 
-            let vm = &vm_interpreter.vm;
+            let vm = &interpreter.vm;
 
-            let method_py_object_ref = unwrap_rust_python_result(vm_scope.globals.get_item(#name, vm), vm);
+            let method_py_object_ref = unwrap_rust_python_result(scope.globals.get_item(#name, vm), vm);
 
             let invoke_result = vm.invoke(&method_py_object_ref, #params);
 

--- a/kybra/compiler/kybra_generate/src/canister_method/query_or_update/rust.rs
+++ b/kybra/compiler/kybra_generate/src/canister_method/query_or_update/rust.rs
@@ -33,18 +33,18 @@ pub fn generate_body(
 
     Ok(quote! {
         unsafe {
-            let _kybra_interpreter = _KYBRA_INTERPRETER_OPTION.as_mut().unwrap();
-            let _kybra_scope = _KYBRA_SCOPE_OPTION.as_mut().unwrap();
+            let vm_interpreter = VM_INTERPRETER_OPTION.as_mut().unwrap();
+            let vm_scope = VM_SCOPE.as_mut().unwrap();
 
-            let vm = &_kybra_interpreter.vm;
+            let vm = &vm_interpreter.vm;
 
-            let method_py_object_ref = _kybra_unwrap_rust_python_result(_kybra_scope.globals.get_item(#name, vm), vm);
+            let method_py_object_ref = unwrap_rust_python_result(vm_scope.globals.get_item(#name, vm), vm);
 
             let invoke_result = vm.invoke(&method_py_object_ref, #params);
 
             match invoke_result {
                 Ok(py_object_ref) => {
-                    let _kybra_final_return_value = _kybra_async_result_handler(vm, &py_object_ref, vm.ctx.none()).await;
+                    let final_return_value = async_result_handler(vm, &py_object_ref, vm.ctx.none()).await;
 
                     #return_expression
                 },
@@ -75,7 +75,7 @@ fn generate_return_expression(
     }
 
     Ok(quote! {
-        _kybra_final_return_value.try_from_vm_value(vm).unwrap()
+        final_return_value.try_from_vm_value(vm).unwrap()
     })
 }
 

--- a/kybra/compiler/kybra_generate/src/canister_method/rust.rs
+++ b/kybra/compiler/kybra_generate/src/canister_method/rust.rs
@@ -26,11 +26,11 @@ impl SourceMapped<&Located<StmtKind>> {
                 let params = tuple::generate_tuple(&param_conversions);
 
                 Ok(quote! {
-                    let vm_interpreter = VM_INTERPRETER_OPTION.as_mut().unwrap();
-                    let vm_scope = VM_SCOPE.as_mut().unwrap();
+                    let interpreter = INTERPRETER_OPTION.as_mut().unwrap();
+                    let scope = SCOPE_OPTION.as_mut().unwrap();
 
-                    vm_interpreter.enter(|vm| {
-                        let method_py_object_ref = unwrap_rust_python_result(vm_scope.globals.get_item(#function_name, vm), vm);
+                    interpreter.enter(|vm| {
+                        let method_py_object_ref = unwrap_rust_python_result(scope.globals.get_item(#function_name, vm), vm);
 
                         let result_py_object_ref = vm.invoke(&method_py_object_ref, #params);
 

--- a/kybra/compiler/kybra_generate/src/canister_method/rust.rs
+++ b/kybra/compiler/kybra_generate/src/canister_method/rust.rs
@@ -26,11 +26,11 @@ impl SourceMapped<&Located<StmtKind>> {
                 let params = tuple::generate_tuple(&param_conversions);
 
                 Ok(quote! {
-                    let _kybra_interpreter = _KYBRA_INTERPRETER_OPTION.as_mut().unwrap();
-                    let _kybra_scope = _KYBRA_SCOPE_OPTION.as_mut().unwrap();
+                    let vm_interpreter = VM_INTERPRETER_OPTION.as_mut().unwrap();
+                    let vm_scope = VM_SCOPE.as_mut().unwrap();
 
-                    _kybra_interpreter.enter(|vm| {
-                        let method_py_object_ref = _kybra_unwrap_rust_python_result(_kybra_scope.globals.get_item(#function_name, vm), vm);
+                    vm_interpreter.enter(|vm| {
+                        let method_py_object_ref = unwrap_rust_python_result(vm_scope.globals.get_item(#function_name, vm), vm);
 
                         let result_py_object_ref = vm.invoke(&method_py_object_ref, #params);
 

--- a/kybra/compiler/kybra_generate/src/guard_function/guard_function.rs
+++ b/kybra/compiler/kybra_generate/src/guard_function/guard_function.rs
@@ -5,7 +5,7 @@ pub fn generate(function_name: &String) -> TokenStream {
     quote! {
         unsafe {
             // TODO is this a security vulnerability?
-            if _KYBRA_INTERPRETER_OPTION.is_none() {
+            if VM_INTERPRETER_OPTION.is_none() {
                 return Ok(());
             }
 

--- a/kybra/compiler/kybra_generate/src/guard_function/guard_function.rs
+++ b/kybra/compiler/kybra_generate/src/guard_function/guard_function.rs
@@ -5,15 +5,15 @@ pub fn generate(function_name: &String) -> TokenStream {
     quote! {
         unsafe {
             // TODO is this a security vulnerability?
-            if VM_INTERPRETER_OPTION.is_none() {
+            if INTERPRETER_OPTION.is_none() {
                 return Ok(());
             }
 
-            let vm_interpreter = VM_INTERPRETER_OPTION.as_mut().unwrap();
-            let vm_scope = VM_SCOPE.as_mut().unwrap();
-            vm_interpreter.enter(|vm| {
+            let interpreter = INTERPRETER_OPTION.as_mut().unwrap();
+            let scope = SCOPE_OPTION.as_mut().unwrap();
+            interpreter.enter(|vm| {
                 let method_py_object_ref =
-                    unwrap_rust_python_result(vm_scope.globals.get_item(#function_name, vm), vm);
+                    unwrap_rust_python_result(scope.globals.get_item(#function_name, vm), vm);
                 let result_py_object_ref = vm.invoke(&method_py_object_ref, ());
                 match result_py_object_ref {
                     Ok(py_object_ref) => py_object_ref.try_from_vm_value(vm).unwrap(),

--- a/kybra/compiler/kybra_generate/src/guard_function/guard_function.rs
+++ b/kybra/compiler/kybra_generate/src/guard_function/guard_function.rs
@@ -4,11 +4,11 @@ use quote::quote;
 pub fn generate(function_name: &String) -> TokenStream {
     quote! {
         unsafe{
-            let _kybra_interpreter = _KYBRA_INTERPRETER_OPTION.as_mut().unwrap();
-            let _kybra_scope = _KYBRA_SCOPE_OPTION.as_mut().unwrap();
-            _kybra_interpreter.enter(|vm| {
+            let vm_interpreter = VM_INTERPRETER_OPTION.as_mut().unwrap();
+            let vm_scope = VM_SCOPE.as_mut().unwrap();
+            vm_interpreter.enter(|vm| {
                 let method_py_object_ref =
-                    _kybra_unwrap_rust_python_result(_kybra_scope.globals.get_item(#function_name, vm), vm);
+                    unwrap_rust_python_result(vm_scope.globals.get_item(#function_name, vm), vm);
                 let result_py_object_ref = vm.invoke(&method_py_object_ref, ());
                 match result_py_object_ref {
                     Ok(py_object_ref) => py_object_ref.try_from_vm_value(vm).unwrap(),

--- a/kybra/compiler/kybra_generate/src/header/mod.rs
+++ b/kybra/compiler/kybra_generate/src/header/mod.rs
@@ -14,8 +14,8 @@ pub fn generate() -> TokenStream {
 
         #ref_cells
 
-        static mut _KYBRA_INTERPRETER_OPTION: Option<rustpython_vm::Interpreter> = None;
-        static mut _KYBRA_SCOPE_OPTION: Option<rustpython_vm::scope::Scope> = None;
+        static mut VM_INTERPRETER_OPTION: Option<rustpython_vm::Interpreter> = None;
+        static mut VM_SCOPE: Option<rustpython_vm::scope::Scope> = None;
 
         // TODO this is broken https://github.com/dfinity/motoko/issues/3462#issuecomment-1260060874
         // #[link_section = "icp:public cdk"]

--- a/kybra/compiler/kybra_generate/src/header/mod.rs
+++ b/kybra/compiler/kybra_generate/src/header/mod.rs
@@ -14,8 +14,8 @@ pub fn generate() -> TokenStream {
 
         #ref_cells
 
-        static mut VM_INTERPRETER_OPTION: Option<rustpython_vm::Interpreter> = None;
-        static mut VM_SCOPE: Option<rustpython_vm::scope::Scope> = None;
+        static mut INTERPRETER_OPTION: Option<rustpython_vm::Interpreter> = None;
+        static mut SCOPE_OPTION: Option<rustpython_vm::scope::Scope> = None;
 
         // TODO this is broken https://github.com/dfinity/motoko/issues/3462#issuecomment-1260060874
         // #[link_section = "icp:public cdk"]

--- a/kybra/compiler/kybra_generate/src/header/use_statements.rs
+++ b/kybra/compiler/kybra_generate/src/header/use_statements.rs
@@ -2,15 +2,31 @@ use proc_macro2::TokenStream;
 
 pub fn generate() -> TokenStream {
     quote::quote! {
-        use rustpython_vm::{AsObject, builtins::{PyDict, PyBaseException, PyGenerator, PyListRef, PyTupleRef, PyIntRef, PyStr, PyList, PyTuple, PyBytes}, class::PyClassImpl, convert::ToPyObject, function::IntoFuncArgs, PyObjectRef, PyObject, PyRef, VirtualMachine, protocol::{PyIter, PyIterReturn}};
-        use rustpython_derive::{pyclass, PyPayload};
+        use candid::{Decode, Encode};
         use kybra_vm_value_derive::{CdkActTryIntoVmValue, CdkActTryFromVmValue};
-        use std::str::FromStr;
-        use ic_cdk::api::call::CallResult;
-        use serde::de::{DeserializeSeed, Visitor};
-        use serde::ser::{Serialize, SerializeMap, SerializeSeq, SerializeTuple};
-        use slotmap::Key as KybraSlotMapKey; // Renamed to avoid clashes with user-defined types
-        use rand::{Rng, SeedableRng, rngs::StdRng};
-        use std::convert::TryInto;
+        use rand::Rng as _KybraTraitRng;
+        use rustpython_vm::{
+            class::PyClassImpl as _KybraTraitPyClassImpl,
+            convert::ToPyObject as _KybraTraitToPyObject,
+            function::IntoFuncArgs as _KybraTraitIntoFuncArgs,
+            AsObject as _KybraTraitAsObject,
+        };
+        use serde::{
+            de::{
+                DeserializeSeed as _KybraTraitDeserializeSeed,
+                Visitor as _KybraTraitVisitor
+            },
+            ser::{
+                Serialize as _KybraTraitSerialize,
+                SerializeMap as _KybraTraitSerializeMap,
+                SerializeSeq as _KybraTraitSerializeSeq,
+                SerializeTuple as _KybraTraitSerializeTuple
+            }
+        };
+        use slotmap::Key as _KybraTraitSlotMapKey;
+        use std::{
+            convert::TryInto as _KybraTraitTryInto,
+            str::FromStr as _KybraTraitFromStr
+        };
     }
 }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/accept_message.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/accept_message.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_accept_message(
+        fn accept_message(
             &self,
             vm: &rustpython_vm::VirtualMachine
         ) -> rustpython_vm::PyObjectRef {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/accept_message.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/accept_message.rs
@@ -4,7 +4,10 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_accept_message(&self, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_accept_message(
+            &self,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::call::accept_message().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/arg_data_raw.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/arg_data_raw.rs
@@ -4,7 +4,10 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_arg_data_raw(&self, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_arg_data_raw(
+            &self,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::call::arg_data_raw().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/arg_data_raw.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/arg_data_raw.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_arg_data_raw(
+        fn arg_data_raw(
             &self,
             vm: &rustpython_vm::VirtualMachine
         ) -> rustpython_vm::PyObjectRef {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/arg_data_raw_size.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/arg_data_raw_size.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_arg_data_raw_size(
+        fn arg_data_raw_size(
             &self,
             vm: &rustpython_vm::VirtualMachine
         ) -> rustpython_vm::PyObjectRef {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/arg_data_raw_size.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/arg_data_raw_size.rs
@@ -4,7 +4,10 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_arg_data_raw_size(&self, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_arg_data_raw_size(
+            &self,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::call::arg_data_raw_size().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/caller.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/caller.rs
@@ -4,7 +4,10 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_caller(&self, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_caller(
+            &self,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::caller().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/caller.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/caller.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_caller(
+        fn caller(
             &self,
             vm: &rustpython_vm::VirtualMachine
         ) -> rustpython_vm::PyObjectRef {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/candid_decode.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/candid_decode.rs
@@ -4,7 +4,11 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_candid_decode(&self, candid_encoded_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_candid_decode(
+            &self,
+            candid_encoded_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let candid_encoded: Vec<u8> = candid_encoded_py_object_ref.try_from_vm_value(vm).unwrap();
             let candid_args: candid::IDLArgs = candid::IDLArgs::from_bytes(&candid_encoded).unwrap();
             let candid_string = candid_args.to_string();

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/candid_decode.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/candid_decode.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_candid_decode(
+        fn candid_decode(
             &self,
             candid_encoded_py_object_ref: rustpython_vm::PyObjectRef,
             vm: &rustpython_vm::VirtualMachine

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/candid_encode.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/candid_encode.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_candid_encode(
+        fn candid_encode(
             &self,
             candid_string_py_object_ref: rustpython_vm::PyObjectRef,
             vm: &rustpython_vm::VirtualMachine

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/candid_encode.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/candid_encode.rs
@@ -4,7 +4,11 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_candid_encode(&self, candid_string_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_candid_encode(
+            &self,
+            candid_string_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let candid_string: String = candid_string_py_object_ref.try_from_vm_value(vm).unwrap();
             let candid_args: candid::IDLArgs = candid_string.parse().unwrap();
             let candid_encoded: Vec<u8> = candid_args.to_bytes().unwrap();

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/canister_balance.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/canister_balance.rs
@@ -4,7 +4,10 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_canister_balance(&self, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_canister_balance(
+            &self,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::canister_balance().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/canister_balance.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/canister_balance.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_canister_balance(
+        fn canister_balance(
             &self,
             vm: &rustpython_vm::VirtualMachine
         ) -> rustpython_vm::PyObjectRef {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/canister_balance128.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/canister_balance128.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_canister_balance128(
+        fn canister_balance128(
             &self,
             vm: &rustpython_vm::VirtualMachine
         ) -> rustpython_vm::PyObjectRef {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/canister_balance128.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/canister_balance128.rs
@@ -4,7 +4,10 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_canister_balance128(&self, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_canister_balance128(
+            &self,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::canister_balance128().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/clear_timer.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/clear_timer.rs
@@ -6,9 +6,9 @@ pub fn generate() -> TokenStream {
         #[pymethod]
         fn _kybra_clear_timer(
             &self,
-            timer_id_py_object_ref: PyObjectRef,
-            vm: &VirtualMachine
-        ) -> PyObjectRef {
+            timer_id_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let timer_id: ic_cdk_timers::TimerId = timer_id_py_object_ref.try_from_vm_value(vm).unwrap();
             ic_cdk_timers::clear_timer(timer_id).try_into_vm_value(vm).unwrap()
         }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/clear_timer.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/clear_timer.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_clear_timer(
+        fn clear_timer(
             &self,
             timer_id_py_object_ref: rustpython_vm::PyObjectRef,
             vm: &rustpython_vm::VirtualMachine

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/data_certificate.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/data_certificate.rs
@@ -4,7 +4,10 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_data_certificate(&self, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_data_certificate(
+            &self,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::data_certificate().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/data_certificate.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/data_certificate.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_data_certificate(
+        fn data_certificate(
             &self,
             vm: &rustpython_vm::VirtualMachine
         ) -> rustpython_vm::PyObjectRef {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/id.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/id.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_id(&self, vm: &rustpython_vm::VirtualMachine) -> rustpython_vm::PyObjectRef {
+        fn id(&self, vm: &rustpython_vm::VirtualMachine) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::id().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/id.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/id.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_id(&self, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_id(&self, vm: &rustpython_vm::VirtualMachine) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::id().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/method_name.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/method_name.rs
@@ -4,7 +4,10 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_method_name(&self, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_method_name(
+            &self,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::call::method_name().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/method_name.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/method_name.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_method_name(
+        fn method_name(
             &self,
             vm: &rustpython_vm::VirtualMachine
         ) -> rustpython_vm::PyObjectRef {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_accept.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_accept.rs
@@ -4,7 +4,11 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_msg_cycles_accept(&self, max_amount_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_msg_cycles_accept(
+            &self,
+            max_amount_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let max_amount: u64 = max_amount_py_object_ref.try_from_vm_value(vm).unwrap();
             ic_cdk::api::call::msg_cycles_accept(max_amount).try_into_vm_value(vm).unwrap()
         }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_accept.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_accept.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_msg_cycles_accept(
+        fn msg_cycles_accept(
             &self,
             max_amount_py_object_ref: rustpython_vm::PyObjectRef,
             vm: &rustpython_vm::VirtualMachine

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_accept128.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_accept128.rs
@@ -4,7 +4,11 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_msg_cycles_accept128(&self, max_amount_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_msg_cycles_accept128(
+            &self,
+            max_amount_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let max_amount: u128 = max_amount_py_object_ref.try_from_vm_value(vm).unwrap();
             ic_cdk::api::call::msg_cycles_accept128(max_amount).try_into_vm_value(vm).unwrap()
         }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_accept128.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_accept128.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_msg_cycles_accept128(
+        fn msg_cycles_accept128(
             &self,
             max_amount_py_object_ref: rustpython_vm::PyObjectRef,
             vm: &rustpython_vm::VirtualMachine

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_available.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_available.rs
@@ -4,7 +4,10 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_msg_cycles_available(&self, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_msg_cycles_available(
+            &self,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::call::msg_cycles_available().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_available.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_available.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_msg_cycles_available(
+        fn msg_cycles_available(
             &self,
             vm: &rustpython_vm::VirtualMachine
         ) -> rustpython_vm::PyObjectRef {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_available128.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_available128.rs
@@ -4,7 +4,10 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_msg_cycles_available128(&self, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_msg_cycles_available128(
+            &self,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::call::msg_cycles_available128().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_available128.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_available128.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_msg_cycles_available128(
+        fn msg_cycles_available128(
             &self,
             vm: &rustpython_vm::VirtualMachine
         ) -> rustpython_vm::PyObjectRef {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_refunded.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_refunded.rs
@@ -4,7 +4,10 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_msg_cycles_refunded(&self, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_msg_cycles_refunded(
+            &self,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::call::msg_cycles_refunded().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_refunded.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_refunded.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_msg_cycles_refunded(
+        fn msg_cycles_refunded(
             &self,
             vm: &rustpython_vm::VirtualMachine
         ) -> rustpython_vm::PyObjectRef {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_refunded128.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_refunded128.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_msg_cycles_refunded128(
+        fn msg_cycles_refunded128(
             &self,
             vm: &rustpython_vm::VirtualMachine
         ) -> rustpython_vm::PyObjectRef {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_refunded128.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/msg_cycles_refunded128.rs
@@ -4,7 +4,10 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_msg_cycles_refunded128(&self, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_msg_cycles_refunded128(
+            &self,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::call::msg_cycles_refunded128().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/notify_functions.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/notify_functions.rs
@@ -13,7 +13,7 @@ use crate::{keywords, tuple};
 pub fn generate(services: &Vec<Service>) -> Vec<TokenStream> {
     services.iter().map(|canister| {
         canister.methods.iter().map(|method| {
-            let function_name_string = format!("_kybra_notify_{}_{}", canister.name, method.name);
+            let function_name_string = format!("notify_{}_{}", canister.name, method.name);
             let real_function_name = format_ident!("{}", function_name_string);
             let wrapper_fn_name = format_ident!("{}_wrapper", function_name_string);
             let param_variable_definitions = generate_param_variables(method, &canister.name);

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/notify_functions.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/notify_functions.rs
@@ -25,7 +25,11 @@ pub fn generate(services: &Vec<Service>) -> Vec<TokenStream> {
 
             quote!{
                 #[pymethod]
-                fn #wrapper_fn_name(&self, args_py_object_refs: Vec<PyObjectRef>, vm: &VirtualMachine) -> PyObjectRef {
+                fn #wrapper_fn_name(
+                    &self,
+                    args_py_object_refs: Vec<rustpython_vm::PyObjectRef>,
+                    vm: &rustpython_vm::VirtualMachine
+                ) -> rustpython_vm::PyObjectRef {
                     let canister_id_principal: ic_cdk::export::Principal = args_py_object_refs[0].clone().try_from_vm_value(vm).unwrap();
 
                     #(#param_variable_definitions)*

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/notify_raw.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/notify_raw.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_notify_raw(
+        fn notify_raw(
             &self,
             canister_id_py_object_ref: rustpython_vm::PyObjectRef,
             method_py_object_ref: rustpython_vm::PyObjectRef,

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/notify_raw.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/notify_raw.rs
@@ -4,7 +4,14 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_notify_raw(&self, canister_id_py_object_ref: PyObjectRef, method_py_object_ref: PyObjectRef, args_raw_py_object_ref: PyObjectRef, payment_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_notify_raw(
+            &self,
+            canister_id_py_object_ref: rustpython_vm::PyObjectRef,
+            method_py_object_ref: rustpython_vm::PyObjectRef,
+            args_raw_py_object_ref: rustpython_vm::PyObjectRef,
+            payment_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let canister_id_principal: ic_cdk::export::Principal = canister_id_py_object_ref.try_from_vm_value(vm).unwrap();
             let method_string: String = method_py_object_ref.try_from_vm_value(vm).unwrap();
             let args_raw_vec: Vec<u8> = args_raw_py_object_ref.try_from_vm_value(vm).unwrap();

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/notify_with_payment128_functions.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/notify_with_payment128_functions.rs
@@ -13,7 +13,7 @@ use crate::{keywords, tuple};
 pub fn generate(services: &Vec<Service>) -> Vec<TokenStream> {
     services.iter().map(|canister| {
         canister.methods.iter().map(|method| {
-            let function_name_string = format!("_kybra_notify_with_payment128_{}_{}", canister.name, method.name);
+            let function_name_string = format!("notify_with_payment128_{}_{}", canister.name, method.name);
             let real_function_name = format_ident!("{}", function_name_string);
             let wrapper_fn_name = format_ident!("{}_wrapper", function_name_string);
             let param_variable_definitions = generate_param_variables(method, &canister.name);

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/notify_with_payment128_functions.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/notify_with_payment128_functions.rs
@@ -25,7 +25,11 @@ pub fn generate(services: &Vec<Service>) -> Vec<TokenStream> {
 
             quote!{
                 #[pymethod]
-                fn #wrapper_fn_name(&self, args_py_object_refs: Vec<PyObjectRef>, vm: &VirtualMachine) -> PyObjectRef {
+                fn #wrapper_fn_name(
+                    &self,
+                    args_py_object_refs: Vec<rustpython_vm::PyObjectRef>,
+                    vm: &rustpython_vm::VirtualMachine
+                ) -> rustpython_vm::PyObjectRef {
                     let canister_id_principal: ic_cdk::export::Principal = args_py_object_refs[0].clone().try_from_vm_value(vm).unwrap();
 
                     #(#param_variable_definitions)*

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/performance_counter.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/performance_counter.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_performance_counter(
+        fn performance_counter(
             &self,
             counter_type_py_object_ref: rustpython_vm::PyObjectRef,
             vm: &rustpython_vm::VirtualMachine

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/performance_counter.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/performance_counter.rs
@@ -4,7 +4,11 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_performance_counter(&self, counter_type_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_performance_counter(
+            &self,
+            counter_type_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let counter_type: u32 = counter_type_py_object_ref.try_from_vm_value(vm).unwrap();
 
             ic_cdk::api::call::performance_counter(counter_type).try_into_vm_value(vm).unwrap()

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/print.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/print.rs
@@ -4,7 +4,11 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_print(&self, param_py_object_ref: PyObjectRef, vm: &VirtualMachine) {
+        fn _kybra_print(
+            &self,
+            param_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) {
             let param_string: String = param_py_object_ref.try_into_value(vm).unwrap();
             ic_cdk::println!("{:#?}", param_string);
         }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/print.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/print.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_print(
+        fn print(
             &self,
             param_py_object_ref: rustpython_vm::PyObjectRef,
             vm: &rustpython_vm::VirtualMachine

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/reject.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/reject.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_reject(
+        fn reject(
             &self,
             reject_py_object_ref: rustpython_vm::PyObjectRef,
             vm: &rustpython_vm::VirtualMachine

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/reject.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/reject.rs
@@ -4,7 +4,11 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_reject(&self, reject_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_reject(
+            &self,
+            reject_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let reject_message: String = reject_py_object_ref.try_from_vm_value(vm).unwrap();
             ic_cdk::api::call::reject(reject_message.as_str()).try_into_vm_value(vm).unwrap()
         }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/reject_code.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/reject_code.rs
@@ -4,7 +4,10 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_reject_code(&self, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_reject_code(
+            &self,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::call::reject_code().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/reject_code.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/reject_code.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_reject_code(
+        fn reject_code(
             &self,
             vm: &rustpython_vm::VirtualMachine
         ) -> rustpython_vm::PyObjectRef {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/reject_message.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/reject_message.rs
@@ -4,7 +4,10 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_reject_message(&self, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_reject_message(
+            &self,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::call::reject_message().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/reject_message.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/reject_message.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_reject_message(
+        fn reject_message(
             &self,
             vm: &rustpython_vm::VirtualMachine
         ) -> rustpython_vm::PyObjectRef {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/reply.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/reply.rs
@@ -17,7 +17,12 @@ pub fn generate(
     let match_arms = generate_match_arms(canister_methods, query_methods);
     quote! {
         #[pymethod]
-        fn _kybra_reply(&self, first_called_function_name_py_object_ref: PyObjectRef, reply_value_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_reply(
+            &self,
+            first_called_function_name_py_object_ref: rustpython_vm::PyObjectRef,
+            reply_value_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let first_called_function_name: String = first_called_function_name_py_object_ref.try_from_vm_value(vm).unwrap();
 
             match &first_called_function_name[..] {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/reply.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/reply.rs
@@ -17,7 +17,7 @@ pub fn generate(
     let match_arms = generate_match_arms(canister_methods, query_methods);
     quote! {
         #[pymethod]
-        fn _kybra_reply(
+        fn reply(
             &self,
             first_called_function_name_py_object_ref: rustpython_vm::PyObjectRef,
             reply_value_py_object_ref: rustpython_vm::PyObjectRef,

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/reply_raw.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/reply_raw.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_reply_raw(
+        fn reply_raw(
             &self,
             buf_vector_py_object_ref: rustpython_vm::PyObjectRef,
             vm: &rustpython_vm::VirtualMachine

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/reply_raw.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/reply_raw.rs
@@ -4,7 +4,11 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_reply_raw(&self, buf_vector_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_reply_raw(
+            &self,
+            buf_vector_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let buf_vector: Vec<u8> = buf_vector_py_object_ref.try_from_vm_value(vm).unwrap();
             ic_cdk::api::call::reply_raw(&buf_vector).try_into_vm_value(vm).unwrap()
         }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/set_certified_data.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/set_certified_data.rs
@@ -4,7 +4,11 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_set_certified_data(&self, data_py_object_ref: PyObjectRef, vm: &VirtualMachine) {
+        fn _kybra_set_certified_data(
+            &self,
+            data_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) {
             let data: Vec<u8> = data_py_object_ref.try_from_vm_value(vm).unwrap();
             ic_cdk::api::set_certified_data(&data).try_into_vm_value(vm).unwrap();
         }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/set_certified_data.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/set_certified_data.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_set_certified_data(
+        fn set_certified_data(
             &self,
             data_py_object_ref: rustpython_vm::PyObjectRef,
             vm: &rustpython_vm::VirtualMachine

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/set_timer.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/set_timer.rs
@@ -15,10 +15,10 @@ pub fn generate() -> TokenStream {
 
             let closure = move || {
                 unsafe {
-                    let vm_interpreter = VM_INTERPRETER_OPTION.as_mut().unwrap();
-                    let vm_scope = VM_SCOPE.as_mut().unwrap();
+                    let interpreter = INTERPRETER_OPTION.as_mut().unwrap();
+                    let scope = SCOPE_OPTION.as_mut().unwrap();
 
-                    let vm = &vm_interpreter.vm;
+                    let vm = &interpreter.vm;
 
                     let result_py_object_ref = vm.invoke(&func_py_object_ref, ());
 

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/set_timer.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/set_timer.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_set_timer(
+        fn set_timer(
             &self,
             delay_py_object_ref: rustpython_vm::PyObjectRef,
             func_py_object_ref: rustpython_vm::PyObjectRef,
@@ -15,17 +15,17 @@ pub fn generate() -> TokenStream {
 
             let closure = move || {
                 unsafe {
-                    let _kybra_interpreter = _KYBRA_INTERPRETER_OPTION.as_mut().unwrap();
-                    let _kybra_scope = _KYBRA_SCOPE_OPTION.as_mut().unwrap();
+                    let vm_interpreter = VM_INTERPRETER_OPTION.as_mut().unwrap();
+                    let vm_scope = VM_SCOPE.as_mut().unwrap();
 
-                    let vm = &_kybra_interpreter.vm;
+                    let vm = &vm_interpreter.vm;
 
                     let result_py_object_ref = vm.invoke(&func_py_object_ref, ());
 
                     match result_py_object_ref {
                         Ok(py_object_ref) => {
                             ic_cdk::spawn(async move {
-                                _kybra_async_result_handler(vm, &py_object_ref, vm.ctx.none()).await;
+                                async_result_handler(vm, &py_object_ref, vm.ctx.none()).await;
                             });
                         },
                         Err(err) => {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/set_timer.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/set_timer.rs
@@ -6,10 +6,10 @@ pub fn generate() -> TokenStream {
         #[pymethod]
         fn _kybra_set_timer(
             &self,
-            delay_py_object_ref: PyObjectRef,
-            func_py_object_ref: PyObjectRef,
-            vm: &VirtualMachine
-        ) -> PyObjectRef {
+            delay_py_object_ref: rustpython_vm::PyObjectRef,
+            func_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let delay_as_u64: u64 = delay_py_object_ref.try_from_vm_value(vm).unwrap();
             let delay = core::time::Duration::new(delay_as_u64, 0);
 

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/set_timer_interval.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/set_timer_interval.rs
@@ -15,10 +15,10 @@ pub fn generate() -> TokenStream {
 
             let closure = move || {
                 unsafe {
-                    let vm_interpreter = VM_INTERPRETER_OPTION.as_mut().unwrap();
-                    let vm_scope = VM_SCOPE.as_mut().unwrap();
+                    let interpreter = INTERPRETER_OPTION.as_mut().unwrap();
+                    let scope = SCOPE_OPTION.as_mut().unwrap();
 
-                    let vm = &vm_interpreter.vm;
+                    let vm = &interpreter.vm;
 
                     let result_py_object_ref = vm.invoke(&func_py_object_ref, ());
 

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/set_timer_interval.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/set_timer_interval.rs
@@ -6,10 +6,10 @@ pub fn generate() -> TokenStream {
         #[pymethod]
         fn _kybra_set_timer_interval(
             &self,
-            interval_py_object_ref: PyObjectRef,
-            func_py_object_ref: PyObjectRef,
-            vm: &VirtualMachine
-        ) -> PyObjectRef {
+            interval_py_object_ref: rustpython_vm::PyObjectRef,
+            func_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let interval_as_u64: u64 = interval_py_object_ref.try_from_vm_value(vm).unwrap();
             let interval = core::time::Duration::new(interval_as_u64, 0);
 

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/set_timer_interval.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/set_timer_interval.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_set_timer_interval(
+        fn set_timer_interval(
             &self,
             interval_py_object_ref: rustpython_vm::PyObjectRef,
             func_py_object_ref: rustpython_vm::PyObjectRef,
@@ -15,17 +15,17 @@ pub fn generate() -> TokenStream {
 
             let closure = move || {
                 unsafe {
-                    let _kybra_interpreter = _KYBRA_INTERPRETER_OPTION.as_mut().unwrap();
-                    let _kybra_scope = _KYBRA_SCOPE_OPTION.as_mut().unwrap();
+                    let vm_interpreter = VM_INTERPRETER_OPTION.as_mut().unwrap();
+                    let vm_scope = VM_SCOPE.as_mut().unwrap();
 
-                    let vm = &_kybra_interpreter.vm;
+                    let vm = &vm_interpreter.vm;
 
                     let result_py_object_ref = vm.invoke(&func_py_object_ref, ());
 
                     match result_py_object_ref {
                         Ok(py_object_ref) => {
                             ic_cdk::spawn(async move {
-                                _kybra_async_result_handler(vm, &py_object_ref, vm.ctx.none()).await;
+                                async_result_handler(vm, &py_object_ref, vm.ctx.none()).await;
                             });
                         },
                         Err(err) => {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable64_grow.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable64_grow.rs
@@ -4,7 +4,12 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_stable64_grow(&self, new_pages_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_stable64_grow(
+            &self,
+            new_pages_py_object_ref:
+            rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let new_pages: u64 = new_pages_py_object_ref.try_from_vm_value(vm).unwrap();
             ic_cdk::api::stable::stable64_grow(new_pages).try_into_vm_value(vm).unwrap()
         }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable64_grow.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable64_grow.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_stable64_grow(
+        fn stable64_grow(
             &self,
             new_pages_py_object_ref:
             rustpython_vm::PyObjectRef,

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable64_read.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable64_read.rs
@@ -4,7 +4,12 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_stable64_read(&self, offset_py_object_ref: PyObjectRef, length_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_stable64_read(
+            &self,
+            offset_py_object_ref: rustpython_vm::PyObjectRef,
+            length_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let offset: u64 = offset_py_object_ref.try_from_vm_value(vm).unwrap();
             let length: u64 = length_py_object_ref.try_from_vm_value(vm).unwrap();
 

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable64_read.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable64_read.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_stable64_read(
+        fn stable64_read(
             &self,
             offset_py_object_ref: rustpython_vm::PyObjectRef,
             length_py_object_ref: rustpython_vm::PyObjectRef,

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable64_size.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable64_size.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_stable64_size(
+        fn stable64_size(
             &self,
             vm: &rustpython_vm::VirtualMachine
         ) -> rustpython_vm::PyObjectRef {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable64_size.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable64_size.rs
@@ -4,7 +4,10 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_stable64_size(&self, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_stable64_size(
+            &self,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::stable::stable64_size().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable64_write.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable64_write.rs
@@ -4,7 +4,12 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_stable64_write(&self, offset_py_object_ref: PyObjectRef, buf_vector_py_object_ref: PyObjectRef, vm: &VirtualMachine) {
+        fn _kybra_stable64_write(
+            &self,
+            offset_py_object_ref: rustpython_vm::PyObjectRef,
+            buf_vector_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine,
+        ) {
             let offset: u64 = offset_py_object_ref.try_from_vm_value(vm).unwrap();
             let buf_vector: Vec<u8> = buf_vector_py_object_ref.try_from_vm_value(vm).unwrap();
             let buf: &[u8] = &buf_vector[..];

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable64_write.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable64_write.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_stable64_write(
+        fn stable64_write(
             &self,
             offset_py_object_ref: rustpython_vm::PyObjectRef,
             buf_vector_py_object_ref: rustpython_vm::PyObjectRef,

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/contains_key.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/contains_key.rs
@@ -8,7 +8,7 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> TokenStrea
 
     quote! {
         #[pymethod]
-        fn _kybra_stable_b_tree_map_contains_key(
+        fn stable_b_tree_map_contains_key(
             &self,
             memory_id_py_object_ref: rustpython_vm::PyObjectRef,
             key_py_object_ref: rustpython_vm::PyObjectRef,

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/contains_key.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/contains_key.rs
@@ -8,7 +8,12 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> TokenStrea
 
     quote! {
         #[pymethod]
-        fn _kybra_stable_b_tree_map_contains_key(&self, memory_id_py_object_ref: PyObjectRef, key_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_stable_b_tree_map_contains_key(
+            &self,
+            memory_id_py_object_ref: rustpython_vm::PyObjectRef,
+            key_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let memory_id: u8 = memory_id_py_object_ref.try_from_vm_value(vm).unwrap();
 
             match memory_id {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/get.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/get.rs
@@ -8,7 +8,7 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> TokenStrea
 
     quote! {
         #[pymethod]
-        fn _kybra_stable_b_tree_map_get(
+        fn stable_b_tree_map_get(
             &self,
             memory_id_py_object_ref: rustpython_vm::PyObjectRef,
             key_py_object_ref: rustpython_vm::PyObjectRef,

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/get.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/get.rs
@@ -8,7 +8,12 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> TokenStrea
 
     quote! {
         #[pymethod]
-        fn _kybra_stable_b_tree_map_get(&self, memory_id_py_object_ref: PyObjectRef, key_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_stable_b_tree_map_get(
+            &self,
+            memory_id_py_object_ref: rustpython_vm::PyObjectRef,
+            key_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let memory_id: u8 = memory_id_py_object_ref.try_from_vm_value(vm).unwrap();
 
             match memory_id {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/insert.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/insert.rs
@@ -8,7 +8,13 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> TokenStrea
 
     quote! {
         #[pymethod]
-        fn _kybra_stable_b_tree_map_insert(&self, memory_id_py_object_ref: PyObjectRef, key_py_object_ref: PyObjectRef, value_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_stable_b_tree_map_insert(
+            &self,
+            memory_id_py_object_ref: rustpython_vm::PyObjectRef,
+            key_py_object_ref: rustpython_vm::PyObjectRef,
+            value_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let memory_id: u8 = memory_id_py_object_ref.try_from_vm_value(vm).unwrap();
 
             match memory_id {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/insert.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/insert.rs
@@ -8,7 +8,7 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> TokenStrea
 
     quote! {
         #[pymethod]
-        fn _kybra_stable_b_tree_map_insert(
+        fn stable_b_tree_map_insert(
             &self,
             memory_id_py_object_ref: rustpython_vm::PyObjectRef,
             key_py_object_ref: rustpython_vm::PyObjectRef,

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/is_empty.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/is_empty.rs
@@ -8,7 +8,11 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> TokenStrea
 
     quote! {
         #[pymethod]
-        fn _kybra_stable_b_tree_map_is_empty(&self, memory_id_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_stable_b_tree_map_is_empty(
+            &self,
+            memory_id_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let memory_id: u8 = memory_id_py_object_ref.try_from_vm_value(vm).unwrap();
 
             match memory_id {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/is_empty.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/is_empty.rs
@@ -8,7 +8,7 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> TokenStrea
 
     quote! {
         #[pymethod]
-        fn _kybra_stable_b_tree_map_is_empty(
+        fn stable_b_tree_map_is_empty(
             &self,
             memory_id_py_object_ref: rustpython_vm::PyObjectRef,
             vm: &rustpython_vm::VirtualMachine

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/items.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/items.rs
@@ -8,7 +8,11 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> TokenStrea
 
     quote! {
         #[pymethod]
-        fn _kybra_stable_b_tree_map_items(&self, memory_id_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        fn _kybra_stable_b_tree_map_items(
+            &self,
+            memory_id_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> Vec<rustpython_vm::PyObjectRef> {
             let memory_id: u8 = memory_id_py_object_ref.try_from_vm_value(vm).unwrap();
 
             match memory_id {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/items.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/items.rs
@@ -8,7 +8,7 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> TokenStrea
 
     quote! {
         #[pymethod]
-        fn _kybra_stable_b_tree_map_items(
+        fn stable_b_tree_map_items(
             &self,
             memory_id_py_object_ref: rustpython_vm::PyObjectRef,
             vm: &rustpython_vm::VirtualMachine

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/keys.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/keys.rs
@@ -8,7 +8,11 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> TokenStrea
 
     quote! {
         #[pymethod]
-        fn _kybra_stable_b_tree_map_keys(&self, memory_id_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        fn _kybra_stable_b_tree_map_keys(
+            &self,
+            memory_id_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> Vec<rustpython_vm::PyObjectRef> {
             let memory_id: u8 = memory_id_py_object_ref.try_from_vm_value(vm).unwrap();
 
             match memory_id {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/keys.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/keys.rs
@@ -8,7 +8,7 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> TokenStrea
 
     quote! {
         #[pymethod]
-        fn _kybra_stable_b_tree_map_keys(
+        fn stable_b_tree_map_keys(
             &self,
             memory_id_py_object_ref: rustpython_vm::PyObjectRef,
             vm: &rustpython_vm::VirtualMachine

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/len.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/len.rs
@@ -8,7 +8,11 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> TokenStrea
 
     quote! {
         #[pymethod]
-        fn _kybra_stable_b_tree_map_len(&self, memory_id_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_stable_b_tree_map_len(
+            &self,
+            memory_id_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let memory_id: u8 = memory_id_py_object_ref.try_from_vm_value(vm).unwrap();
 
             match memory_id {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/len.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/len.rs
@@ -8,7 +8,7 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> TokenStrea
 
     quote! {
         #[pymethod]
-        fn _kybra_stable_b_tree_map_len(
+        fn stable_b_tree_map_len(
             &self,
             memory_id_py_object_ref: rustpython_vm::PyObjectRef,
             vm: &rustpython_vm::VirtualMachine

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/remove.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/remove.rs
@@ -8,7 +8,7 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> TokenStrea
 
     quote! {
         #[pymethod]
-        fn _kybra_stable_b_tree_map_remove(
+        fn stable_b_tree_map_remove(
             &self,
             memory_id_py_object_ref: rustpython_vm::PyObjectRef,
             key_py_object_ref: rustpython_vm::PyObjectRef,

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/remove.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/remove.rs
@@ -8,7 +8,12 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> TokenStrea
 
     quote! {
         #[pymethod]
-        fn _kybra_stable_b_tree_map_remove(&self, memory_id_py_object_ref: PyObjectRef, key_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_stable_b_tree_map_remove(
+            &self,
+            memory_id_py_object_ref: rustpython_vm::PyObjectRef,
+            key_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let memory_id: u8 = memory_id_py_object_ref.try_from_vm_value(vm).unwrap();
 
             match memory_id {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/values.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/values.rs
@@ -8,7 +8,11 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> TokenStrea
 
     quote! {
         #[pymethod]
-        fn _kybra_stable_b_tree_map_values(&self, memory_id_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        fn _kybra_stable_b_tree_map_values(
+            &self,
+            memory_id_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> Vec<rustpython_vm::PyObjectRef> {
             let memory_id: u8 = memory_id_py_object_ref.try_from_vm_value(vm).unwrap();
 
             match memory_id {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/values.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_b_tree_map/values.rs
@@ -8,7 +8,7 @@ pub fn generate(stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>) -> TokenStrea
 
     quote! {
         #[pymethod]
-        fn _kybra_stable_b_tree_map_values(
+        fn stable_b_tree_map_values(
             &self,
             memory_id_py_object_ref: rustpython_vm::PyObjectRef,
             vm: &rustpython_vm::VirtualMachine

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_bytes.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_bytes.rs
@@ -4,7 +4,10 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_stable_bytes(&self, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_stable_bytes(
+            &self,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::stable::stable_bytes().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_bytes.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_bytes.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_stable_bytes(
+        fn stable_bytes(
             &self,
             vm: &rustpython_vm::VirtualMachine
         ) -> rustpython_vm::PyObjectRef {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_grow.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_grow.rs
@@ -4,7 +4,11 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_stable_grow(&self, new_pages_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_stable_grow(
+            &self,
+            new_pages_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let new_pages: u32 = new_pages_py_object_ref.try_from_vm_value(vm).unwrap();
             ic_cdk::api::stable::stable_grow(new_pages).try_into_vm_value(vm).unwrap()
         }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_grow.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_grow.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_stable_grow(
+        fn stable_grow(
             &self,
             new_pages_py_object_ref: rustpython_vm::PyObjectRef,
             vm: &rustpython_vm::VirtualMachine

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_read.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_read.rs
@@ -4,7 +4,12 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_stable_read(&self, offset_py_object_ref: PyObjectRef, length_py_object_ref: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_stable_read(
+            &self,
+            offset_py_object_ref: rustpython_vm::PyObjectRef,
+            length_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             let offset: u32 = offset_py_object_ref.try_from_vm_value(vm).unwrap();
             let length: u32 = length_py_object_ref.try_from_vm_value(vm).unwrap();
 

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_read.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_read.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_stable_read(
+        fn stable_read(
             &self,
             offset_py_object_ref: rustpython_vm::PyObjectRef,
             length_py_object_ref: rustpython_vm::PyObjectRef,

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_size.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_size.rs
@@ -4,7 +4,10 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_stable_size(&self, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_stable_size(
+            &self,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::stable::stable_size().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_size.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_size.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_stable_size(
+        fn stable_size(
             &self,
             vm: &rustpython_vm::VirtualMachine
         ) -> rustpython_vm::PyObjectRef {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_write.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_write.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_stable_write(
+        fn stable_write(
             &self,
             offset_py_object_ref: rustpython_vm::PyObjectRef,
             buf_vector_py_object_ref: rustpython_vm::PyObjectRef,

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/stable_write.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/stable_write.rs
@@ -4,7 +4,12 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_stable_write(&self, offset_py_object_ref: PyObjectRef, buf_vector_py_object_ref: PyObjectRef, vm: &VirtualMachine) {
+        fn _kybra_stable_write(
+            &self,
+            offset_py_object_ref: rustpython_vm::PyObjectRef,
+            buf_vector_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) {
             let offset: u32 = offset_py_object_ref.try_from_vm_value(vm).unwrap();
             let buf_vector: Vec<u8> = buf_vector_py_object_ref.try_from_vm_value(vm).unwrap();
             let buf: &[u8] = &buf_vector[..];

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/time.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/time.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_time(
+        fn time(
             &self,
             vm: &rustpython_vm::VirtualMachine
         ) -> rustpython_vm::PyObjectRef {

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/time.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/time.rs
@@ -4,7 +4,10 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_time(&self, vm: &VirtualMachine) -> PyObjectRef {
+        fn _kybra_time(
+            &self,
+            vm: &rustpython_vm::VirtualMachine
+        ) -> rustpython_vm::PyObjectRef {
             ic_cdk::api::time().try_into_vm_value(vm).unwrap()
         }
     }

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/trap.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/trap.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_trap(
+        fn trap(
             &self,
             message_py_object_ref: rustpython_vm::PyObjectRef,
             vm: &rustpython_vm::VirtualMachine

--- a/kybra/compiler/kybra_generate/src/ic_object/functions/trap.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/functions/trap.rs
@@ -4,7 +4,11 @@ use quote::quote;
 pub fn generate() -> TokenStream {
     quote! {
         #[pymethod]
-        fn _kybra_trap(&self, message_py_object_ref: PyObjectRef, vm: &VirtualMachine) {
+        fn _kybra_trap(
+            &self,
+            message_py_object_ref: rustpython_vm::PyObjectRef,
+            vm: &rustpython_vm::VirtualMachine
+        ) {
             let message: String = message_py_object_ref.try_from_vm_value(vm).unwrap();
             ic_cdk::api::trap(&message);
         }

--- a/kybra/compiler/kybra_generate/src/ic_object/mod.rs
+++ b/kybra/compiler/kybra_generate/src/ic_object/mod.rs
@@ -72,11 +72,11 @@ pub fn generate(
     let trap = trap::generate();
 
     quote! {
-        #[pyclass(module = false, name = "ic")]
-        #[derive(Debug, PyPayload)]
+        #[rustpython_derive::pyclass(module = false, name = "ic")]
+        #[derive(Debug, rustpython_derive::PyPayload)]
         struct Ic {}
 
-        #[pyclass]
+        #[rustpython_derive::pyclass]
         impl Ic {
             #accept_message
             #arg_data_raw

--- a/kybra/compiler/kybra_generate/src/kybra_modules_init/mod.rs
+++ b/kybra/compiler/kybra_generate/src/kybra_modules_init/mod.rs
@@ -30,11 +30,11 @@ pub fn generate(
                 keyword_list: crate::keywords::get_python_keywords(),
                 cdk_name: "kybra".to_string(),
             },
-            "_kybra_init".to_string(),
+            "_init".to_string(),
         );
 
         quote! {
-            static #init_param_name: RefCell<Option<#init_param_type_annotation>> = RefCell::new(None);
+            static #init_param_name: std::cell::RefCell<Option<#init_param_type_annotation>> = std::cell::RefCell::new(None);
         }
     });
 
@@ -49,13 +49,24 @@ pub fn generate(
 
     Ok(quote::quote! {
         thread_local! {
-            static INITIALIZED_MAP_REF_CELL: RefCell<ic_stable_structures::cell::Cell<u8, Memory>> = RefCell::new(ic_stable_structures::cell::Cell::init(MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(254))), 0).unwrap());
+            static INITIALIZED_MAP_REF_CELL: std::cell::RefCell<
+                ic_stable_structures::cell::Cell<
+                    u8,
+                    ic_stable_structures::memory_manager::VirtualMemory<
+                        ic_stable_structures::DefaultMemoryImpl
+                    >
+                >
+            > = std::cell::RefCell::new(
+                ic_stable_structures::cell::Cell::init(
+                    MEMORY_MANAGER_REF_CELL.with(|m| m.borrow().get(ic_stable_structures::memory_manager::MemoryId::new(254))), 0
+                ).unwrap()
+            );
 
             #(#params_ref_cells)*
 
-            // static PYTHON_SOURCE_BYTECODE_REF_CELL: RefCell<Vec<u8>> = RefCell::new(vec![]);
-            // static NATIVE_STDLIB_BYTECODE_REF_CELL: RefCell<Vec<u8>> = RefCell::new(vec![]);
-            // static PYTHON_STDLIB_BYTECODE_REF_CELL: RefCell<Vec<u8>> = RefCell::new(vec![]);
+            // static PYTHON_SOURCE_BYTECODE_REF_CELL: std::cell::RefCell<Vec<u8>> = std::cell::RefCell::new(vec![]);
+            // static NATIVE_STDLIB_BYTECODE_REF_CELL: std::cell::RefCell<Vec<u8>> = std::cell::RefCell::new(vec![]);
+            // static PYTHON_STDLIB_BYTECODE_REF_CELL: std::cell::RefCell<Vec<u8>> = std::cell::RefCell::new(vec![]);
         }
 
         #[ic_cdk_macros::update]
@@ -101,7 +112,7 @@ pub fn generate(
                     #call_to_post_upgrade_py_function
                 }
 
-                ic_cdk_timers::set_timer(core::time::Duration::new(0, 0), _cdk_rng_seed);
+                ic_cdk_timers::set_timer(core::time::Duration::new(0, 0), rng_seed);
             }
         }
     })

--- a/kybra/compiler/kybra_generate/src/stable_b_tree_map_nodes/rust/storable_impl.rs
+++ b/kybra/compiler/kybra_generate/src/stable_b_tree_map_nodes/rust/storable_impl.rs
@@ -2,9 +2,9 @@ use proc_macro2::{Ident, TokenStream};
 
 pub fn generate(wrapper_type_name: &Ident) -> TokenStream {
     quote::quote! {
-        impl Storable for #wrapper_type_name {
+        impl ic_stable_structures::Storable for #wrapper_type_name {
             fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-                Cow::Owned(candid::Encode!(self).unwrap())
+                std::borrow::Cow::Owned(candid::Encode!(self).unwrap())
             }
 
             fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {

--- a/kybra/compiler/kybra_generate/src/stable_b_tree_map_nodes/rust/wrapper_type.rs
+++ b/kybra/compiler/kybra_generate/src/stable_b_tree_map_nodes/rust/wrapper_type.rs
@@ -27,7 +27,7 @@ pub fn generate(
     (
         wrapper_struct_name_ident.clone(),
         quote! {
-            #[derive(CandidType, Deserialize, CdkActTryFromVmValue, Ord, PartialOrd, Eq, PartialEq, Clone)]
+            #[derive(candid::CandidType, candid::Deserialize, CdkActTryFromVmValue, Ord, PartialOrd, Eq, PartialEq, Clone)]
             struct #wrapper_struct_name_ident(#key_type);
         },
     )

--- a/kybra/compiler/kybra_generate/src/unwrap_rust_python_result.rs
+++ b/kybra/compiler/kybra_generate/src/unwrap_rust_python_result.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 
 pub fn generate() -> TokenStream {
     quote::quote! {
-        pub fn _kybra_unwrap_rust_python_result<T>(
+        pub fn unwrap_rust_python_result<T>(
             rust_python_result: Result<T, rustpython_vm::PyRef<rustpython_vm::builtins::PyBaseException>>,
             vm: &rustpython::vm::VirtualMachine
         ) -> T {

--- a/kybra/compiler/kybra_generate/src/unwrap_rust_python_result.rs
+++ b/kybra/compiler/kybra_generate/src/unwrap_rust_python_result.rs
@@ -3,7 +3,7 @@ use proc_macro2::TokenStream;
 pub fn generate() -> TokenStream {
     quote::quote! {
         pub fn _kybra_unwrap_rust_python_result<T>(
-            rust_python_result: Result<T, PyRef<PyBaseException>>,
+            rust_python_result: Result<T, rustpython_vm::PyRef<rustpython_vm::builtins::PyBaseException>>,
             vm: &rustpython::vm::VirtualMachine
         ) -> T {
             match rust_python_result {

--- a/kybra/compiler/kybra_generate/src/vm_value_conversion/try_from_vm_value_impls/basic.rs
+++ b/kybra/compiler/kybra_generate/src/vm_value_conversion/try_from_vm_value_impls/basic.rs
@@ -25,7 +25,7 @@ pub fn generate() -> TokenStream {
 
         impl CdkActTryFromVmValue<ic_cdk::export::candid::Func, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<ic_cdk::export::candid::Func, CdkActTryFromVmValueError> {
-                let tuple_self: PyTupleRef = _kybra_unwrap_rust_python_result(self.try_into_value(vm), vm);
+                let tuple_self: rustpython_vm::builtins::PyTupleRef = _kybra_unwrap_rust_python_result(self.try_into_value(vm), vm);
                 let principal = tuple_self.get(0).unwrap();
                 let method = tuple_self.get(1).unwrap();
 

--- a/kybra/compiler/kybra_generate/src/vm_value_conversion/try_from_vm_value_impls/basic.rs
+++ b/kybra/compiler/kybra_generate/src/vm_value_conversion/try_from_vm_value_impls/basic.rs
@@ -25,7 +25,7 @@ pub fn generate() -> TokenStream {
 
         impl CdkActTryFromVmValue<ic_cdk::export::candid::Func, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<ic_cdk::export::candid::Func, CdkActTryFromVmValueError> {
-                let tuple_self: rustpython_vm::builtins::PyTupleRef = _kybra_unwrap_rust_python_result(self.try_into_value(vm), vm);
+                let tuple_self: rustpython_vm::builtins::PyTupleRef = unwrap_rust_python_result(self.try_into_value(vm), vm);
                 let principal = tuple_self.get(0).unwrap();
                 let method = tuple_self.get(1).unwrap();
 
@@ -38,9 +38,9 @@ pub fn generate() -> TokenStream {
 
         impl CdkActTryFromVmValue<ic_cdk::export::Principal, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<ic_cdk::export::Principal, CdkActTryFromVmValueError> {
-                let to_str = _kybra_unwrap_rust_python_result(self.get_attr("to_str", vm), vm);
-                let result = _kybra_unwrap_rust_python_result(vm.invoke(&to_str, ()), vm);
-                let result_string: String = _kybra_unwrap_rust_python_result(result.try_into_value(vm), vm);
+                let to_str = unwrap_rust_python_result(self.get_attr("to_str", vm), vm);
+                let result = unwrap_rust_python_result(vm.invoke(&to_str, ()), vm);
+                let result_string: String = unwrap_rust_python_result(result.try_into_value(vm), vm);
                 Ok(ic_cdk::export::Principal::from_text(result_string).unwrap())
             }
         }
@@ -53,7 +53,7 @@ pub fn generate() -> TokenStream {
 
         impl CdkActTryFromVmValue<ic_cdk_timers::TimerId, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<ic_cdk_timers::TimerId, CdkActTryFromVmValueError> {
-                let vm_value_as_u64: u64 = _kybra_unwrap_rust_python_result(self.try_into_value(vm), vm);
+                let vm_value_as_u64: u64 = unwrap_rust_python_result(self.try_into_value(vm), vm);
                 Ok(ic_cdk_timers::TimerId::from(slotmap::KeyData::from_ffi(vm_value_as_u64)))
             }
         }

--- a/kybra/compiler/kybra_generate/src/vm_value_conversion/try_from_vm_value_impls/numeric.rs
+++ b/kybra/compiler/kybra_generate/src/vm_value_conversion/try_from_vm_value_impls/numeric.rs
@@ -40,7 +40,7 @@ pub fn generate() -> TokenStream {
 
         impl CdkActTryFromVmValue<ic_cdk::export::candid::Int, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<ic_cdk::export::candid::Int, CdkActTryFromVmValueError> {
-                let int_result: Result<PyIntRef, _> = self.try_into_value(vm);
+                let int_result: Result<rustpython_vm::builtins::PyIntRef, _> = self.try_into_value(vm);
 
                 match int_result {
                     Ok(int) => Ok(ic_cdk::export::candid::Int(int.as_bigint().clone())),
@@ -96,7 +96,7 @@ pub fn generate() -> TokenStream {
 
         impl CdkActTryFromVmValue<ic_cdk::export::candid::Nat, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<ic_cdk::export::candid::Nat, CdkActTryFromVmValueError> {
-                let int_result: Result<PyIntRef, _> = self.try_into_value(vm);
+                let int_result: Result<rustpython_vm::builtins::PyIntRef, _> = self.try_into_value(vm);
 
                 match int_result {
                     Ok(int) => Ok(ic_cdk::export::candid::Nat::from_str(&int.as_bigint().to_string()).unwrap()), // TODO probably not the best conversion

--- a/kybra/compiler/kybra_generate/src/vm_value_conversion/try_from_vm_value_impls/vec.rs
+++ b/kybra/compiler/kybra_generate/src/vm_value_conversion/try_from_vm_value_impls/vec.rs
@@ -128,7 +128,7 @@ pub fn generate() -> TokenStream {
         where
             rustpython::vm::PyObjectRef: for<'a> CdkActTryFromVmValue<T, &'a rustpython::vm::VirtualMachine>
         {
-            let py_list: PyListRef = _kybra_unwrap_rust_python_result(py_object_ref.try_into_value(vm), vm);
+            let py_list: rustpython_vm::builtins::PyListRef = _kybra_unwrap_rust_python_result(py_object_ref.try_into_value(vm), vm);
             let vec = py_list.borrow_vec();
 
             Ok(vec.iter().map(|item| {

--- a/kybra/compiler/kybra_generate/src/vm_value_conversion/try_from_vm_value_impls/vec.rs
+++ b/kybra/compiler/kybra_generate/src/vm_value_conversion/try_from_vm_value_impls/vec.rs
@@ -4,85 +4,85 @@ pub fn generate() -> TokenStream {
     quote::quote! {
         impl CdkActTryFromVmValue<Vec<bool>, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<Vec<bool>, CdkActTryFromVmValueError> {
-                Ok(_kybra_unwrap_rust_python_result(self.try_into_value(vm), vm))
+                Ok(unwrap_rust_python_result(self.try_into_value(vm), vm))
             }
         }
 
         impl CdkActTryFromVmValue<Vec<String>, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<Vec<String>, CdkActTryFromVmValueError> {
-                Ok(_kybra_unwrap_rust_python_result(self.try_into_value(vm), vm))
+                Ok(unwrap_rust_python_result(self.try_into_value(vm), vm))
             }
         }
 
         impl CdkActTryFromVmValue<Vec<f64>, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<Vec<f64>, CdkActTryFromVmValueError> {
-                Ok(_kybra_unwrap_rust_python_result(self.try_into_value(vm), vm))
+                Ok(unwrap_rust_python_result(self.try_into_value(vm), vm))
             }
         }
 
         impl CdkActTryFromVmValue<Vec<f32>, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<Vec<f32>, CdkActTryFromVmValueError> {
-                Ok(_kybra_unwrap_rust_python_result(self.try_into_value(vm), vm))
+                Ok(unwrap_rust_python_result(self.try_into_value(vm), vm))
             }
         }
 
         impl CdkActTryFromVmValue<Vec<i128>, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<Vec<i128>, CdkActTryFromVmValueError> {
-                Ok(_kybra_unwrap_rust_python_result(self.try_into_value(vm), vm))
+                Ok(unwrap_rust_python_result(self.try_into_value(vm), vm))
             }
         }
 
         impl CdkActTryFromVmValue<Vec<i64>, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<Vec<i64>, CdkActTryFromVmValueError> {
-                Ok(_kybra_unwrap_rust_python_result(self.try_into_value(vm), vm))
+                Ok(unwrap_rust_python_result(self.try_into_value(vm), vm))
             }
         }
 
         impl CdkActTryFromVmValue<Vec<i32>, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<Vec<i32>, CdkActTryFromVmValueError> {
-                Ok(_kybra_unwrap_rust_python_result(self.try_into_value(vm), vm))
+                Ok(unwrap_rust_python_result(self.try_into_value(vm), vm))
             }
         }
 
         impl CdkActTryFromVmValue<Vec<i16>, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<Vec<i16>, CdkActTryFromVmValueError> {
-                Ok(_kybra_unwrap_rust_python_result(self.try_into_value(vm), vm))
+                Ok(unwrap_rust_python_result(self.try_into_value(vm), vm))
             }
         }
 
         impl CdkActTryFromVmValue<Vec<i8>, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<Vec<i8>, CdkActTryFromVmValueError> {
-                Ok(_kybra_unwrap_rust_python_result(self.try_into_value(vm), vm))
+                Ok(unwrap_rust_python_result(self.try_into_value(vm), vm))
             }
         }
 
         impl CdkActTryFromVmValue<Vec<u128>, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<Vec<u128>, CdkActTryFromVmValueError> {
-                Ok(_kybra_unwrap_rust_python_result(self.try_into_value(vm), vm))
+                Ok(unwrap_rust_python_result(self.try_into_value(vm), vm))
             }
         }
 
         impl CdkActTryFromVmValue<Vec<u64>, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<Vec<u64>, CdkActTryFromVmValueError> {
-                Ok(_kybra_unwrap_rust_python_result(self.try_into_value(vm), vm))
+                Ok(unwrap_rust_python_result(self.try_into_value(vm), vm))
             }
         }
 
         impl CdkActTryFromVmValue<Vec<u32>, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<Vec<u32>, CdkActTryFromVmValueError> {
-                Ok(_kybra_unwrap_rust_python_result(self.try_into_value(vm), vm))
+                Ok(unwrap_rust_python_result(self.try_into_value(vm), vm))
             }
         }
 
         impl CdkActTryFromVmValue<Vec<u16>, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<Vec<u16>, CdkActTryFromVmValueError> {
-                Ok(_kybra_unwrap_rust_python_result(self.try_into_value(vm), vm))
+                Ok(unwrap_rust_python_result(self.try_into_value(vm), vm))
             }
         }
 
         impl CdkActTryFromVmValue<Vec<u8>, &rustpython::vm::VirtualMachine> for rustpython::vm::PyObjectRef {
             fn try_from_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<Vec<u8>, CdkActTryFromVmValueError> {
-                Ok(_kybra_unwrap_rust_python_result(self.try_into_value(vm), vm))
+                Ok(unwrap_rust_python_result(self.try_into_value(vm), vm))
             }
         }
 
@@ -128,7 +128,7 @@ pub fn generate() -> TokenStream {
         where
             rustpython::vm::PyObjectRef: for<'a> CdkActTryFromVmValue<T, &'a rustpython::vm::VirtualMachine>
         {
-            let py_list: rustpython_vm::builtins::PyListRef = _kybra_unwrap_rust_python_result(py_object_ref.try_into_value(vm), vm);
+            let py_list: rustpython_vm::builtins::PyListRef = unwrap_rust_python_result(py_object_ref.try_into_value(vm), vm);
             let vec = py_list.borrow_vec();
 
             Ok(vec.iter().map(|item| {

--- a/kybra/compiler/kybra_generate/src/vm_value_conversion/try_into_vm_value_impls/basic.rs
+++ b/kybra/compiler/kybra_generate/src/vm_value_conversion/try_into_vm_value_impls/basic.rs
@@ -28,7 +28,7 @@ pub fn generate() -> TokenStream {
 
         impl CdkActTryIntoVmValue<&rustpython::vm::VirtualMachine, rustpython::vm::PyObjectRef> for ic_cdk::export::Principal {
             fn try_into_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<rustpython::vm::PyObjectRef, CdkActTryIntoVmValueError> {
-                let principal_class = _kybra_unwrap_rust_python_result(vm.run_block_expr(
+                let principal_class = unwrap_rust_python_result(vm.run_block_expr(
                     vm.new_scope_with_builtins(),
                     r#"
 from kybra import Principal
@@ -37,8 +37,8 @@ Principal
                     "#
                 ), vm);
 
-                let from_str = _kybra_unwrap_rust_python_result(principal_class.get_attr("from_str", vm), vm);
-                let principal_instance = _kybra_unwrap_rust_python_result(vm.invoke(&from_str, (self.to_text(),)), vm);
+                let from_str = unwrap_rust_python_result(principal_class.get_attr("from_str", vm), vm);
+                let principal_instance = unwrap_rust_python_result(vm.invoke(&from_str, (self.to_text(),)), vm);
 
                 Ok(principal_instance)
             }

--- a/kybra/compiler/kybra_generate/src/vm_value_conversion/try_into_vm_value_impls/vec.rs
+++ b/kybra/compiler/kybra_generate/src/vm_value_conversion/try_into_vm_value_impls/vec.rs
@@ -60,29 +60,52 @@ pub fn generate() -> TokenStream {
 
         impl<T> KybraTryIntoVec for Vec<T> {}
 
-        impl<T> CdkActTryIntoVmValue<&rustpython::vm::VirtualMachine, rustpython::vm::PyObjectRef> for Vec<T>
+        impl<T> CdkActTryIntoVmValue<&rustpython::vm::VirtualMachine, rustpython::vm::PyObjectRef>
+            for Vec<T>
         where
             T: KybraTryIntoVec,
-            T: for<'a> CdkActTryIntoVmValue<&'a rustpython::vm::VirtualMachine, rustpython::vm::PyObjectRef>
+            T: for<'a> CdkActTryIntoVmValue<
+                &'a rustpython::vm::VirtualMachine,
+                rustpython::vm::PyObjectRef,
+            >,
         {
-            fn try_into_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<rustpython::vm::PyObjectRef, CdkActTryIntoVmValueError> {
+            fn try_into_vm_value(
+                self,
+                vm: &rustpython::vm::VirtualMachine,
+            ) -> Result<rustpython::vm::PyObjectRef, CdkActTryIntoVmValueError> {
                 try_into_vm_value_generic_array(self, vm)
             }
         }
 
-        impl CdkActTryIntoVmValue<&rustpython::vm::VirtualMachine, rustpython::vm::PyObjectRef> for Vec<u8> {
-            fn try_into_vm_value(self, vm: &rustpython::vm::VirtualMachine) -> Result<rustpython::vm::PyObjectRef, CdkActTryIntoVmValueError> {
+        impl CdkActTryIntoVmValue<&rustpython::vm::VirtualMachine, rustpython::vm::PyObjectRef>
+            for Vec<u8>
+        {
+            fn try_into_vm_value(
+                self,
+                vm: &rustpython::vm::VirtualMachine,
+            ) -> Result<rustpython::vm::PyObjectRef, CdkActTryIntoVmValueError> {
                 Ok(vm.ctx.new_bytes(self).into())
             }
         }
 
-        fn try_into_vm_value_generic_array<T>(generic_array: Vec<T>, vm: &rustpython::vm::VirtualMachine) -> Result<rustpython::vm::PyObjectRef, CdkActTryIntoVmValueError>
+
+        fn try_into_vm_value_generic_array<T>(
+            generic_array: Vec<T>,
+            vm: &rustpython::vm::VirtualMachine,
+        ) -> Result<rustpython::vm::PyObjectRef, CdkActTryIntoVmValueError>
         where
-            T:  for<'a> CdkActTryIntoVmValue<&'a rustpython::vm::VirtualMachine, rustpython::vm::PyObjectRef>
+            T: for<'a> CdkActTryIntoVmValue<
+                &'a rustpython::vm::VirtualMachine,
+                rustpython::vm::PyObjectRef,
+            >,
         {
-            let py_object_refs = generic_array.into_iter().map(|item| item.try_into_vm_value(vm).unwrap()).collect::<Vec<PyObjectRef>>();
+            let py_object_refs = generic_array
+                .into_iter()
+                .map(|item| item.try_into_vm_value(vm).unwrap())
+                .collect::<Vec<rustpython_vm::PyObjectRef>>();
 
             Ok(vm.ctx.new_list(py_object_refs).into())
         }
+
     }
 }

--- a/kybra/compiler/kybra_vm_value_derive/Cargo.toml
+++ b/kybra/compiler/kybra_vm_value_derive/Cargo.toml
@@ -10,4 +10,4 @@ proc_macro = true
 quote = "1.0.17"
 syn = "1.0.90"
 proc-macro2 = "1.0.36"
-cdk_framework = { git = "https://github.com/demergent-labs/cdk_framework", rev = "08a74a4077d0981acde2b0fc714e877bba659b9e" }
+cdk_framework = { git = "https://github.com/demergent-labs/cdk_framework", rev = "13c4abdd72bdcfa6a5b1ddf7f08a4fd83eacb419" }

--- a/kybra/compiler/kybra_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_struct.rs
+++ b/kybra/compiler/kybra_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_struct.rs
@@ -44,7 +44,7 @@ fn generate_field_variable_definitions(data_struct: &DataStruct) -> Vec<TokenStr
                 };
 
                 quote! {
-                    let #field_name = _kybra_unwrap_rust_python_result(self.get_item(stringify!(#restored_field_name), vm), vm);
+                    let #field_name = unwrap_rust_python_result(self.get_item(stringify!(#restored_field_name), vm), vm);
                 }
             })
             .collect(),
@@ -58,7 +58,7 @@ fn generate_field_variable_definitions(data_struct: &DataStruct) -> Vec<TokenStr
 
                 quote! {
                     // TODO tuple_self is being repeated more times than necessary
-                    let tuple_self: rustpython_vm::builtins::PyTupleRef = _kybra_unwrap_rust_python_result(self.clone().try_into_value(vm), vm);
+                    let tuple_self: rustpython_vm::builtins::PyTupleRef = unwrap_rust_python_result(self.clone().try_into_value(vm), vm);
                     let #field_name = tuple_self.get(#syn_index).unwrap();
                 }
             })

--- a/kybra/compiler/kybra_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_struct.rs
+++ b/kybra/compiler/kybra_vm_value_derive/src/derive_try_from_vm_value/derive_try_from_vm_value_struct.rs
@@ -58,7 +58,7 @@ fn generate_field_variable_definitions(data_struct: &DataStruct) -> Vec<TokenStr
 
                 quote! {
                     // TODO tuple_self is being repeated more times than necessary
-                    let tuple_self: PyTupleRef = _kybra_unwrap_rust_python_result(self.clone().try_into_value(vm), vm);
+                    let tuple_self: rustpython_vm::builtins::PyTupleRef = _kybra_unwrap_rust_python_result(self.clone().try_into_value(vm), vm);
                     let #field_name = tuple_self.get(#syn_index).unwrap();
                 }
             })


### PR DESCRIPTION
In order to reduce conlicts with user-defined code, this PR:

- Removes global `use` statements in favor of fully qualified names
- Removes `_kybra_` prefixes from variables/functions in favor of prefixing user-defined variables/functions with `cdk_user_defined_`
- Removes leading underscores on function params where the param is used in the function body

> **Warning**
> Depends on https://github.com/demergent-labs/cdk_framework/pull/70