### PR TITLE
Fixed Guard Functions example

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,7 @@ jobs:
                     "examples/ethereum_json_rpc",
                     "examples/func_types",
                     "examples/generators",
+                    "examples/guard_functions",
                     "examples/heartbeat",
                     "examples/ic_api",
                     "examples/imports",

--- a/examples/guard_functions/src/main.did
+++ b/examples/guard_functions/src/main.did
@@ -1,7 +1,6 @@
 type State = record { counter : int32; heartbeat_tick : int32 };
 service : () -> {
   bad_object_guarded : () -> (bool) query;
-  call_expression_with_empty_options_object : () -> (bool) query;
   call_expression_without_options_object : () -> (bool) query;
   custom_error_guarded : () -> (bool) query;
   error_string_guarded : () -> (bool) query;
@@ -11,6 +10,7 @@ service : () -> {
   loosely_guarded : () -> (bool) query;
   loosely_guarded_manual : () -> (bool) query;
   modify_state_guarded : () -> (bool);
+  name_error_guarded : () -> (bool) query;
   non_null_ok_value_guarded : () -> (bool) query;
   non_string_err_value_guarded : () -> (bool) query;
   tightly_guarded : () -> (bool) query;

--- a/examples/guard_functions/src/main.py
+++ b/examples/guard_functions/src/main.py
@@ -12,12 +12,7 @@ from kybra import (
     void,
 )
 
-
-def adelante() -> GuardResult:
-    ic.print("We are in the adelante")
-    return {
-        "Ok": None,
-    }
+# region Types
 
 
 class State(Record):
@@ -25,7 +20,16 @@ class State(Record):
     heartbeat_tick: int32
 
 
+class CustomError(Exception):
+    def __init__(self, message: str):
+        self.message = message
+
+
+# endregion Types
+
 state: State = {"counter": 0, "heartbeat_tick": 0}
+
+# region GuardFunctions
 
 
 def allow_modify_state_guarded() -> GuardResult:
@@ -75,43 +79,46 @@ def unpassable() -> GuardResult:
 
 
 def throw_string() -> GuardResult:
-    ic.print("throwString called")
+    ic.print("throw_string called")
     raise Exception('Execution halted by "throw string" guard function')
 
 
-class CustomError(Exception):
-    def __init__(self, message: str):
-        self.message = message
-
-
 def throw_custom_error() -> GuardResult:
-    ic.print("throwCustomError called")
+    ic.print("throw_custom_error called")
     raise CustomError('Execution halted by "throw custom error" guard function')
 
 
 def prevent_upgrades() -> GuardResult:
-    ic.print("preventUpgrades called")
+    ic.print("prevent_upgrades called")
     return {"Err": "Upgrades to this canister are disabled"}
 
 
 def return_invalid_type() -> GuardResult:
     ic.print("return_invalid_type called")
-    return "Something other than a guard result" # type: ignore
+    return "Something other than a guard result"  # type: ignore
 
 
 def return_non_guard_result_object() -> GuardResult:
     ic.print("return_non_guard_result_object called")
-    return {badProp: "Something other than a guard result"} # type: ignore
+    return {"badProp": "Something other than a guard result"}  # type: ignore
 
 
 def return_non_null_ok_value() -> GuardResult:
     ic.print("non_null_ok_value called")
-    return {Ok: "Something other than null"} # type: ignore
+    return {"Ok": "Something other than null"}  # type: ignore
 
 
 def return_non_string_err_value() -> GuardResult:
     ic.print("non_string_err_value called")
-    return {Err: {badProp: "Something other than a string"}} # type: ignore
+    return {"Err": {"badProp": "Something other than a string"}}  # type: ignore
+
+
+def name_error() -> GuardResult:
+    ic.print("name_error called")
+    return {Ok: "'Ok' key should be string, not symbol"}  # type: ignore
+
+
+# endregion GuardFunctions
 
 
 @query
@@ -119,7 +126,6 @@ def get_state() -> State:
     return state
 
 
-# Guarded functions are called
 @inspect_message(guard=allow_modify_state_guarded)
 def inspect_message_() -> void:
     ic.print("inspect message called")
@@ -157,12 +163,6 @@ def call_expression_without_options_object() -> bool:
     return True
 
 
-@query
-def call_expression_with_empty_options_object() -> bool:
-    ic.print("call_expression_with_empty_option_object called")
-    return True
-
-
 @query(guard=allow_all)
 def loosely_guarded() -> bool:
     ic.print("loosely_guarded called")
@@ -171,6 +171,7 @@ def loosely_guarded() -> bool:
 
 @query(guard=allow_all)
 def loosely_guarded_manual() -> Manual[bool]:
+    ic.print("loosely_guarded_manual called")
     ic.reply(True)
 
 
@@ -208,23 +209,29 @@ def custom_error_guarded() -> bool:
 # Execution halted by runtime error
 @query(guard=return_invalid_type)
 def invalid_return_type_guarded() -> bool:
-    ic.print("invalidReturnTypeGuarded called")
+    ic.print("invalid_return_type_guarded called")
     return True
 
 
 @query(guard=return_non_guard_result_object)
 def bad_object_guarded() -> bool:
-    ic.print("badObjectGuarded called")
+    ic.print("bad_object_guarded called")
     return True
 
 
 @query(guard=return_non_null_ok_value)
 def non_null_ok_value_guarded() -> bool:
-    ic.print("nonNullOkValueGuarded called")
+    ic.print("non_null_ok_value_guarded called")
     return True
 
 
 @query(guard=return_non_string_err_value)
 def non_string_err_value_guarded() -> bool:
-    ic.print("nonStringErrValueGuarded called")
+    ic.print("non_string_err_value_guarded called")
+    return True
+
+
+@query(guard=name_error)
+def name_error_guarded() -> bool:
+    ic.print("name_error_guarded called")
     return True

--- a/examples/guard_functions/src/main.py
+++ b/examples/guard_functions/src/main.py
@@ -115,7 +115,7 @@ def return_non_string_err_value() -> GuardResult:
 
 def name_error() -> GuardResult:
     ic.print("name_error called")
-    return {Ok: "'Ok' key should be string, not symbol"}  # type: ignore
+    return {Ok: "'Ok' key should be a string, not an identifier"}  # type: ignore
 
 
 # endregion GuardFunctions

--- a/examples/guard_functions/test/test.ts
+++ b/examples/guard_functions/test/test.ts
@@ -12,6 +12,7 @@ const functionGuardCanister = createActor('rrkah-fqaaa-aaaaa-aaaaq-cai', {
 let tests: Test[] = [
     ...getTests(createSnakeCaseProxy(functionGuardCanister)).filter((value) => {
         return (
+            value.name !== 'callExpressionWithEmptyOptionsObject' &&
             value.name !== 'looselyGuardedWithGuardOptionKeyAsString' &&
             value.name !== 'invalidReturnTypeGuarded' &&
             value.name !== 'badObjectGuarded' &&
@@ -19,7 +20,6 @@ let tests: Test[] = [
             value.name !== 'nonStringErrValueGuarded'
         );
     }),
-    // TODO we should make these errors more presentable
     {
         name: 'invalid_return_type_guarded',
         test: async () => {
@@ -31,7 +31,7 @@ let tests: Test[] = [
             } catch (err) {
                 return {
                     Ok: (err as AgentError).message.includes(
-                        'TypeError: Expected NoneType but received str'
+                        'TypeError: expected Result but received str'
                     )
                 };
             }
@@ -46,7 +46,7 @@ let tests: Test[] = [
             } catch (err) {
                 return {
                     Ok: (err as AgentError).message.includes(
-                        'NameError(\\"name \'badProp\' is not defined\\")'
+                        'TypeError: expected Result but received dict'
                     )
                 };
             }
@@ -63,7 +63,7 @@ let tests: Test[] = [
             } catch (err) {
                 return {
                     Ok: (err as AgentError).message.includes(
-                        'NameError(\\"name \'Ok\' is not defined\\")'
+                        'TypeError: expected NoneType but received str'
                     )
                 };
             }
@@ -80,7 +80,24 @@ let tests: Test[] = [
             } catch (err) {
                 return {
                     Ok: (err as AgentError).message.includes(
-                        'NameError(\\"name \'Err\' is not defined\\")'
+                        'TypeError: expected str but received dict'
+                    )
+                };
+            }
+        }
+    },
+    {
+        name: 'name_error_guarded',
+        test: async () => {
+            try {
+                await functionGuardCanister.name_error_guarded();
+                return {
+                    Err: 'name_error_guarded should have had an error'
+                };
+            } catch (err) {
+                return {
+                    Ok: (err as AgentError).message.includes(
+                        "NameError: name 'Ok' is not defined"
                     )
                 };
             }

--- a/kybra/compiler/kybra_generate/src/guard_function/guard_function.rs
+++ b/kybra/compiler/kybra_generate/src/guard_function/guard_function.rs
@@ -38,7 +38,8 @@ pub fn generate(function_name: &String) -> TokenStream {
                         }
                     })?
                     .try_from_vm_value(vm)
-                    .map_err(|vmc_err| format!("TypeError: {}", vmc_err.0))?
+                    // .map_err(|vmc_err| "TypeError: value is not a GuardResult".to_string())?
+                    .map_err(|vmc_err| vmc_err.0)?
             })
         }
     }

--- a/kybra/compiler/kybra_generate/src/guard_function/guard_function.rs
+++ b/kybra/compiler/kybra_generate/src/guard_function/guard_function.rs
@@ -17,7 +17,7 @@ pub fn generate(function_name: &String) -> TokenStream {
                 .ok_or_else(|| "SystemError: missing python scope".to_string())?;
 
             interpreter.enter(|vm| {
-                let method_py_object_ref = scope
+                scope
                     .globals
                     .get_item(#function_name, vm)
                     .map_err(|err| {
@@ -27,9 +27,7 @@ pub fn generate(function_name: &String) -> TokenStream {
                             Ok(err_message) => format!("{type_name}: {}", err_message.to_string()),
                             Err(_) => format!("Attribute Error: '{type_name}' object has no attribute '__str__'"),
                         }
-                    })?;
-
-                let py_object_ref = method_py_object_ref
+                    })?
                     .call((), vm)
                     .map_err(|err| {
                         let py_object = err.to_pyobject(vm);
@@ -38,9 +36,9 @@ pub fn generate(function_name: &String) -> TokenStream {
                             Ok(err_message) => format!("{type_name}: {}", err_message.to_string()),
                             Err(_) => format!("Attribute Error: '{type_name}' object has no attribute '__str__'"),
                         }
-                    })?;
-
-                py_object_ref.try_from_vm_value(vm).map_err(|err| err.0)
+                    })?
+                    .try_from_vm_value(vm)
+                    .map_err(|vmc_err| format!("TypeError: {}", vmc_err.0))?
             })
         }
     }

--- a/kybra/compiler/kybra_generate/src/guard_function/guard_function.rs
+++ b/kybra/compiler/kybra_generate/src/guard_function/guard_function.rs
@@ -38,7 +38,6 @@ pub fn generate(function_name: &String) -> TokenStream {
                         }
                     })?
                     .try_from_vm_value(vm)
-                    // .map_err(|vmc_err| "TypeError: value is not a GuardResult".to_string())?
                     .map_err(|vmc_err| vmc_err.0)?
             })
         }


### PR DESCRIPTION
When getting runtime errors enabled I broke the return values from guard functions. This PR corrects that change and re-enables the example in CI/CD.

Additionally it improves the wording of some of the vm value conversion messages.