### PR TITLE
Improve Python Stdlib Conditional Compilation Check

### DIFF
--- a/kybra/build_wasm_binary_or_exit.py
+++ b/kybra/build_wasm_binary_or_exit.py
@@ -3,6 +3,7 @@ import shutil
 import subprocess
 import sys
 
+import kybra
 from kybra.colors import red
 from kybra.timed import timed_inline
 from kybra.types import Paths
@@ -46,8 +47,11 @@ def check_if_python_stdlib_installed(
             "--network",
             str(os.environ.get("DFX_NETWORK")),
             "call",
+            "--output",
+            "json",
             canister_name,
             "_kybra_check_if_python_stdlib_installed",
+            f'("{kybra.__version__}")',
         ],
         cargo_env,
         False,  # Passing verbose along as True messes with the std outputs
@@ -61,7 +65,7 @@ def check_if_python_stdlib_installed(
     if verbose == True:
         print(check_if_python_stdlib_installed)
 
-    return check_if_python_stdlib_installed == "(true)"
+    return check_if_python_stdlib_installed == "true"
 
 
 def get_cargo_build_features(python_stdlib_is_installed: bool) -> str:

--- a/kybra/compiler/kybra_generate/src/body/check_if_python_stdlib_installed.rs
+++ b/kybra/compiler/kybra_generate/src/body/check_if_python_stdlib_installed.rs
@@ -1,10 +1,10 @@
 use proc_macro2::TokenStream;
 
-pub fn generate() -> TokenStream {
+pub fn generate(kybra_version: &str) -> TokenStream {
     quote::quote! {
         #[ic_cdk_macros::query(guard="guard_against_non_controllers", hidden = true)]
-        pub fn _kybra_check_if_python_stdlib_installed() -> bool {
-            PYTHON_STDLIB_STABLE_REF_CELL.with(|python_stdlib_stable_ref_cell| python_stdlib_stable_ref_cell.borrow().get().len() > 0)
+        pub fn _kybra_check_if_python_stdlib_installed(kybra_version: String) -> bool {
+            kybra_version == #kybra_version && PYTHON_STDLIB_STABLE_REF_CELL.with(|python_stdlib_stable_ref_cell| python_stdlib_stable_ref_cell.borrow().get().len() > 0)
         }
     }
 }

--- a/kybra/compiler/kybra_generate/src/body/mod.rs
+++ b/kybra/compiler/kybra_generate/src/body/mod.rs
@@ -18,10 +18,12 @@ pub fn generate(
     query_methods: &Vec<QueryMethod>,
     services: &Vec<Service>,
     stable_b_tree_map_nodes: &Vec<StableBTreeMapNode>,
+    kybra_version: &str,
 ) -> TokenStream {
     let async_result_handler = async_result_handler::generate(&services);
     let call_global_python_function = call_global_python_function::generate();
-    let check_if_python_stdlib_installed = check_if_python_stdlib_installed::generate();
+    let check_if_python_stdlib_installed =
+        check_if_python_stdlib_installed::generate(kybra_version);
     let guard_against_non_controllers = guard_against_non_controllers::generate();
     let ic_object = ic_object::generate(
         update_methods,

--- a/kybra/compiler/kybra_generate/src/canister_method/errors/multiple_system_methods.rs
+++ b/kybra/compiler/kybra_generate/src/canister_method/errors/multiple_system_methods.rs
@@ -26,7 +26,7 @@ impl MultipleSystemMethods {
                 .iter()
                 .map(|stmt| stmt.create_location())
                 .collect(),
-            method_type: method_type,
+            method_type,
         }
         .into()
     }

--- a/kybra/compiler/kybra_generate/src/lib.rs
+++ b/kybra/compiler/kybra_generate/src/lib.rs
@@ -28,8 +28,9 @@ pub use stable_b_tree_map_nodes::StableBTreeMapNode;
 pub fn generate_canister(
     py_file_names: &Vec<&str>,
     entry_module_name: &str,
+    kybra_version: &str,
 ) -> Result<TokenStream, Vec<Error>> {
-    PyAst::new(py_file_names, entry_module_name)
+    PyAst::new(py_file_names, entry_module_name, kybra_version)
         .map_err(|py_ast_errors| {
             py_ast_errors
                 .into_iter()

--- a/kybra/compiler/kybra_generate/src/main.rs
+++ b/kybra/compiler/kybra_generate/src/main.rs
@@ -16,6 +16,7 @@ fn main() {
     let py_file_names_path = &args[1];
     let py_entry_module_name = &args[2];
     let output_file_path = &args[3];
+    let kybra_version = &args[4];
 
     let py_file_names_string = fs::read_to_string(py_file_names_path).unwrap_or_else(|err| {
         eprintln!("Error reading {py_file_names_path}: {err}");
@@ -23,7 +24,7 @@ fn main() {
     });
     let py_file_names: Vec<&str> = py_file_names_string.split(",").collect();
 
-    let lib_file = generate_canister(&py_file_names, &py_entry_module_name)
+    let lib_file = generate_canister(&py_file_names, py_entry_module_name, kybra_version)
         .unwrap_or_else(|errors| {
             eprintln!("Canister compilation failed:");
             for error in errors {

--- a/kybra/compiler/kybra_generate/src/py_ast/py_ast.rs
+++ b/kybra/compiler/kybra_generate/src/py_ast/py_ast.rs
@@ -9,10 +9,15 @@ use crate::source_map::{SourceMap, SourceMapped};
 pub struct PyAst {
     pub source_mapped_mods: Vec<SourceMapped<Mod>>,
     pub entry_module_name: String,
+    pub kybra_version: String,
 }
 
 impl PyAst {
-    pub fn new(py_file_names: &Vec<&str>, entry_module_name: &str) -> Result<PyAst, Vec<Error>> {
+    pub fn new(
+        py_file_names: &Vec<&str>,
+        entry_module_name: &str,
+        kybra_version: &str,
+    ) -> Result<PyAst, Vec<Error>> {
         // TODO: Use collect_results from CDK Framework instead once
         // https://github.com/demergent-labs/cdk_framework/pull/75 is merged.
         let (source_mapped_mods, errors) = py_file_names
@@ -38,6 +43,7 @@ impl PyAst {
             return Ok(PyAst {
                 source_mapped_mods,
                 entry_module_name: entry_module_name.to_string(),
+                kybra_version: kybra_version.to_string(),
             });
         }
 

--- a/kybra/compiler/kybra_generate/src/py_ast/to_act.rs
+++ b/kybra/compiler/kybra_generate/src/py_ast/to_act.rs
@@ -34,6 +34,7 @@ impl PyAst {
                 &canister_methods.query_methods,
                 &candid_types.services,
                 &stable_b_tree_map_nodes,
+                &self.kybra_version,
             ),
             candid_types,
             canister_methods,

--- a/kybra/run_kybra_generate_or_exit.py
+++ b/kybra/run_kybra_generate_or_exit.py
@@ -76,6 +76,7 @@ def execute_generate_process(
             paths["py_file_names_file"],
             paths["py_entry_module_name"],
             paths["lib"],
+            kybra.__version__,
         ],
         capture_output=not verbose,
         env=cargo_env,


### PR DESCRIPTION
We now use the Kybra version as an additional check on the Python stdlib. Every change in the Kybra version that a canister was compiled against will invoke a new compilation of the Python stdlib